### PR TITLE
Add Phoenix LiveView dashboard scaffold

### DIFF
--- a/dashboard_gen/.formatter.exs
+++ b/dashboard_gen/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/dashboard_gen/.gitignore
+++ b/dashboard_gen/.gitignore
@@ -1,0 +1,24 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+dashboard_gen-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/
+.env

--- a/dashboard_gen/README.md
+++ b/dashboard_gen/README.md
@@ -1,0 +1,21 @@
+# DashboardGen
+
+**TODO: Add description**
+
+## Installation
+
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed
+by adding `dashboard_gen` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:dashboard_gen, "~> 0.1.0"}
+  ]
+end
+```
+
+Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
+and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
+be found at <https://hexdocs.pm/dashboard_gen>.
+

--- a/dashboard_gen/assets/css/app.css
+++ b/dashboard_gen/assets/css/app.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/dashboard_gen/assets/js/app.js
+++ b/dashboard_gen/assets/js/app.js
@@ -1,0 +1,1 @@
+import "./phx"

--- a/dashboard_gen/assets/tailwind.config.js
+++ b/dashboard_gen/assets/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './js/**/*.js',
+    '../lib/*_web/**/*.*ex'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/dashboard_gen/config/config.exs
+++ b/dashboard_gen/config/config.exs
@@ -1,0 +1,34 @@
+import Config
+
+config :dashboard_gen,
+  ecto_repos: [DashboardGen.Repo]
+
+config :dashboard_gen, DashboardGenWeb.Endpoint,
+  url: [host: "localhost"],
+  render_errors: [view: DashboardGenWeb.ErrorHTML, accepts: ~w(html json), layout: false],
+  pubsub_server: DashboardGen.PubSub,
+  live_view: [signing_salt: "SA1tSaLt"]
+
+config :esbuild,
+  version: "0.7.0",
+  default: [
+    args: ~w(js/app.js --bundle --target=es2017 --outdir=../priv/static/assets),
+    cd: Path.expand("../assets", __DIR__),
+    env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
+  ]
+
+config :tailwind,
+  version: "3.3.0",
+  default: [
+    args:
+      ~w(--config=tailwind.config.js --input=css/app.css --output=../priv/static/assets/app.css),
+    cd: Path.expand("../assets", __DIR__)
+  ]
+
+config :logger, :console,
+  format: "$time $metadata[$level] $message\n",
+  metadata: [:request_id]
+
+config :phoenix, :json_library, Jason
+
+import_config "#{config_env()}.exs"

--- a/dashboard_gen/config/dev.exs
+++ b/dashboard_gen/config/dev.exs
@@ -1,0 +1,39 @@
+import Config
+
+# Configure your database
+config :dashboard_gen, DashboardGen.Repo,
+  username: "postgres",
+  password: "postgres",
+  hostname: "localhost",
+  database: "dashboard_gen_dev",
+  stacktrace: true,
+  show_sensitive_data_on_connection_error: true,
+  pool_size: 10
+
+# For development, we disable any cache and enable
+# debugging and code reloading.
+config :dashboard_gen, DashboardGenWeb.Endpoint,
+  http: [ip: {127, 0, 0, 1}, port: 4000],
+  check_origin: false,
+  code_reloader: true,
+  debug_errors: true,
+  secret_key_base: "DEV_SECRET_KEY_BASE",
+  watchers: [
+    esbuild: {Esbuild, :install_and_run, [~w(--sourcemap=inline --watch)]},
+    tailwind: {Tailwind, :install_and_run, [~w(--watch)]}
+  ]
+
+# Watch static and templates for browser reloading.
+config :dashboard_gen, DashboardGenWeb.Endpoint,
+  live_reload: [
+    patterns: [
+      ~r"priv/static/.*(js|css|png|jpeg|jpg|gif|svg)$",
+      ~r"priv/gettext/.*(po)$",
+      ~r"lib/dashboard_gen_web/(controllers|live|components)/.*(ex|heex)$"
+    ]
+  ]
+
+config :logger, level: :debug
+
+config :phoenix, :stacktrace_depth, 20
+config :phoenix, :plug_init_mode, :runtime

--- a/dashboard_gen/config/prod.exs
+++ b/dashboard_gen/config/prod.exs
@@ -1,0 +1,14 @@
+import Config
+
+config :dashboard_gen, DashboardGen.Repo,
+  url: System.get_env("DATABASE_URL"),
+  pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10")
+
+config :dashboard_gen, DashboardGenWeb.Endpoint,
+  url: [host: System.get_env("PHX_HOST"), port: 443],
+  http: [ip: {0, 0, 0, 0}, port: String.to_integer(System.get_env("PORT") || "4000")],
+  secret_key_base: System.fetch_env!("SECRET_KEY_BASE"),
+  cache_static_manifest: "priv/static/cache_manifest.json",
+  server: true
+
+config :logger, level: :info

--- a/dashboard_gen/config/runtime.exs
+++ b/dashboard_gen/config/runtime.exs
@@ -1,0 +1,13 @@
+import Config
+
+# Load environment variables from .env file if present
+if File.exists?(Path.expand("../.env", __DIR__)) do
+  Dotenvy.source!(Path.expand("../.env", __DIR__))
+end
+
+config :dashboard_gen, DashboardGenWeb.Endpoint,
+  server: true,
+  url: [host: System.get_env("PHX_HOST", "example.com"), port: 443],
+  secret_key_base: System.fetch_env!("SECRET_KEY_BASE")
+
+config :openai, api_key: System.fetch_env!("OPENAI_API_KEY")

--- a/dashboard_gen/config/test.exs
+++ b/dashboard_gen/config/test.exs
@@ -1,0 +1,18 @@
+import Config
+
+# Configure your database
+config :dashboard_gen, DashboardGen.Repo,
+  username: "postgres",
+  password: "postgres",
+  hostname: "localhost",
+  database: "dashboard_gen_test",
+  pool: Ecto.Adapters.SQL.Sandbox,
+  pool_size: 10
+
+# We don't run a server during test.
+config :dashboard_gen, DashboardGenWeb.Endpoint,
+  http: [ip: {127, 0, 0, 1}, port: 4002],
+  secret_key_base: "TEST_SECRET_KEY_BASE",
+  server: false
+
+config :logger, level: :warning

--- a/dashboard_gen/lib/dashboard_gen.ex
+++ b/dashboard_gen/lib/dashboard_gen.ex
@@ -1,0 +1,6 @@
+defmodule DashboardGen do
+  @moduledoc """
+  DashboardGen keeps the contexts that define your domain
+  and business logic.
+  """
+end

--- a/dashboard_gen/lib/dashboard_gen/application.ex
+++ b/dashboard_gen/lib/dashboard_gen/application.ex
@@ -1,0 +1,22 @@
+defmodule DashboardGen.Application do
+  @moduledoc false
+
+  use Application
+
+  def start(_type, _args) do
+    children = [
+      DashboardGenWeb.Telemetry,
+      DashboardGen.Repo,
+      {Phoenix.PubSub, name: DashboardGen.PubSub},
+      DashboardGenWeb.Endpoint
+    ]
+
+    opts = [strategy: :one_for_one, name: DashboardGen.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+
+  def config_change(changed, _new, removed) do
+    DashboardGenWeb.Endpoint.config_change(changed, removed)
+    :ok
+  end
+end

--- a/dashboard_gen/lib/dashboard_gen/dashboards/dashboard.ex
+++ b/dashboard_gen/lib/dashboard_gen/dashboards/dashboard.ex
@@ -1,0 +1,19 @@
+defmodule DashboardGen.Dashboards.Dashboard do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "dashboards" do
+    field(:slug, :string)
+    field(:prompt, :string)
+    field(:response_json, :string)
+    field(:insight_text, :string)
+    timestamps()
+  end
+
+  def changeset(dashboard, attrs) do
+    dashboard
+    |> cast(attrs, [:slug, :prompt, :response_json, :insight_text])
+    |> validate_required([:slug])
+    |> unique_constraint(:slug)
+  end
+end

--- a/dashboard_gen/lib/dashboard_gen/gpt.ex
+++ b/dashboard_gen/lib/dashboard_gen/gpt.ex
@@ -1,0 +1,15 @@
+defmodule DashboardGen.GPT do
+  @moduledoc "Handles communication with OpenAI API"
+
+  def ask(prompt) do
+    body = %{model: "gpt-3.5-turbo", messages: [%{role: "user", content: prompt}]}
+
+    case OpenAI.chat_completion(body) do
+      {:ok, %{choices: [%{"message" => %{"content" => content}}]}} ->
+        Jason.decode(content)
+
+      other ->
+        {:error, other}
+    end
+  end
+end

--- a/dashboard_gen/lib/dashboard_gen/repo.ex
+++ b/dashboard_gen/lib/dashboard_gen/repo.ex
@@ -1,0 +1,5 @@
+defmodule DashboardGen.Repo do
+  use Ecto.Repo,
+    otp_app: :dashboard_gen,
+    adapter: Ecto.Adapters.Postgres
+end

--- a/dashboard_gen/lib/dashboard_gen_web.ex
+++ b/dashboard_gen/lib/dashboard_gen_web.ex
@@ -1,0 +1,39 @@
+defmodule DashboardGenWeb do
+  def controller do
+    quote do
+      use Phoenix.Controller, namespace: DashboardGenWeb
+      import Plug.Conn
+      import DashboardGenWeb.Gettext
+      alias DashboardGenWeb.Router.Helpers, as: Routes
+    end
+  end
+
+  def html do
+    quote do
+      use Phoenix.Component
+      import Phoenix.HTML
+      import DashboardGenWeb.Gettext
+      alias DashboardGenWeb.Router.Helpers, as: Routes
+    end
+  end
+
+  def router do
+    quote do
+      use Phoenix.Router, helpers: false
+      import Phoenix.LiveView.Router
+    end
+  end
+
+  def channel do
+    quote do
+      use Phoenix.Channel
+      import DashboardGenWeb.Gettext
+    end
+  end
+
+  def static_paths, do: ["assets", "favicon.ico", "robots.txt"]
+
+  defmacro __using__(which) when is_atom(which) do
+    apply(__MODULE__, which, [])
+  end
+end

--- a/dashboard_gen/lib/dashboard_gen_web/components/layouts.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/components/layouts.ex
@@ -1,0 +1,5 @@
+defmodule DashboardGenWeb.Layouts do
+  use DashboardGenWeb, :html
+
+  embed_templates("layouts/*")
+end

--- a/dashboard_gen/lib/dashboard_gen_web/components/layouts/root.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/components/layouts/root.html.heex
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <%= csrf_meta_tag() %>
+    <%= live_title_tag assigns[:page_title] || "DashboardGen" %>
+    <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
+  </head>
+  <body>
+    <%= @inner_content %>
+    <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}></script>
+  </body>
+</html>

--- a/dashboard_gen/lib/dashboard_gen_web/controllers/page_controller.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/controllers/page_controller.ex
@@ -1,0 +1,7 @@
+defmodule DashboardGenWeb.PageController do
+  use DashboardGenWeb, :controller
+
+  def home(conn, _params) do
+    render(conn, :index)
+  end
+end

--- a/dashboard_gen/lib/dashboard_gen_web/endpoint.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/endpoint.ex
@@ -1,0 +1,29 @@
+defmodule DashboardGenWeb.Endpoint do
+  use Phoenix.Endpoint, otp_app: :dashboard_gen
+
+  # The session will be stored in the cookie and signed.
+  @session_options [
+    store: :cookie,
+    key: "_dashboard_gen_key",
+    signing_salt: "signsalt"
+  ]
+
+  socket("/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]])
+
+  plug(Plug.Static,
+    at: "/",
+    from: :dashboard_gen,
+    gzip: false,
+    only: DashboardGenWeb.static_paths()
+  )
+
+  if code_reloading? do
+    plug(Phoenix.CodeReloader)
+    plug(Phoenix.Ecto.CheckRepoStatus, otp_app: :dashboard_gen)
+  end
+
+  plug(Plug.RequestId)
+  plug(Plug.Telemetry, event_prefix: [:phoenix, :endpoint])
+  plug(Plug.Session, @session_options)
+  plug(DashboardGenWeb.Router)
+end

--- a/dashboard_gen/lib/dashboard_gen_web/gettext.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/gettext.ex
@@ -1,0 +1,3 @@
+defmodule DashboardGenWeb.Gettext do
+  use Gettext, otp_app: :dashboard_gen
+end

--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
@@ -1,0 +1,16 @@
+defmodule DashboardGenWeb.DashboardLive do
+  use DashboardGenWeb, :live_view
+
+  alias DashboardGen.GPT
+
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, query: "", result: nil)}
+  end
+
+  def handle_event("submit", %{"query" => query}, socket) do
+    case GPT.ask(query) do
+      {:ok, json} -> {:noreply, assign(socket, result: json, query: query)}
+      {:error, reason} -> {:noreply, put_flash(socket, :error, "#{inspect(reason)}")}
+    end
+  end
+end

--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
@@ -1,0 +1,10 @@
+<div class="container mx-auto p-4">
+  <.form let={f} for={:query} phx-submit="submit">
+    <%= text_input f, :query, value: @query, class: "border p-2 w-full" %>
+    <%= submit "Run", class: "mt-2 bg-blue-500 text-white px-4 py-2" %>
+  </.form>
+
+  <%= if @result do %>
+    <pre class="mt-4 bg-gray-100 p-2"><%= Jason.encode!(@result, pretty: true) %></pre>
+  <% end %>
+</div>

--- a/dashboard_gen/lib/dashboard_gen_web/router.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/router.ex
@@ -1,0 +1,20 @@
+defmodule DashboardGenWeb.Router do
+  use DashboardGenWeb, :router
+
+  import Phoenix.LiveView.Router
+
+  pipeline :browser do
+    plug(:accepts, ["html"])
+    plug(:fetch_session)
+    plug(:fetch_live_flash)
+    plug(:put_root_layout, {DashboardGenWeb.Layouts, :root})
+    plug(:protect_from_forgery)
+    plug(:put_secure_browser_headers)
+  end
+
+  scope "/", DashboardGenWeb do
+    pipe_through(:browser)
+
+    live("/", DashboardLive)
+  end
+end

--- a/dashboard_gen/lib/dashboard_gen_web/telemetry.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/telemetry.ex
@@ -1,0 +1,33 @@
+defmodule DashboardGenWeb.Telemetry do
+  use Supervisor
+  import Telemetry.Metrics
+
+  def start_link(arg) do
+    Supervisor.start_link(__MODULE__, arg, name: __MODULE__)
+  end
+
+  def init(_arg) do
+    children = [
+      {Telemetry.Poller, measurements: periodic_measurements(), period: 10_000},
+      {Telemetry.Metrics.ConsoleReporter, metrics: metrics()}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  def metrics do
+    [
+      summary("phoenix.endpoint.stop.duration", unit: {:native, :millisecond}),
+      summary("phoenix.router_dispatch.stop.duration",
+        tags: [:route],
+        unit: {:native, :millisecond}
+      ),
+      summary("phoenix.live_view.mount.stop.duration", unit: {:native, :millisecond}),
+      summary("phoenix.live_view.handle_event.stop.duration", unit: {:native, :millisecond})
+    ]
+  end
+
+  defp periodic_measurements do
+    []
+  end
+end

--- a/dashboard_gen/lib/dashboard_gen_web/templates/layout/root.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/templates/layout/root.html.heex
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <%= csrf_meta_tag() %>
+    <%= live_title_tag assigns[:page_title] || "DashboardGen" %>
+    <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
+  </head>
+  <body>
+    <%= @inner_content %>
+    <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}></script>
+  </body>
+</html>

--- a/dashboard_gen/lib/dashboard_gen_web/templates/page/index.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/templates/page/index.html.heex
@@ -1,0 +1,1 @@
+<h1>Welcome to DashboardGen</h1>

--- a/dashboard_gen/mix.exs
+++ b/dashboard_gen/mix.exs
@@ -1,0 +1,61 @@
+defmodule DashboardGen.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :dashboard_gen,
+      version: "0.1.0",
+      elixir: "~> 1.15",
+      elixirc_paths: elixirc_paths(Mix.env()),
+      compilers: [:phoenix] ++ Mix.compilers(),
+      start_permanent: Mix.env() == :prod,
+      aliases: aliases(),
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      mod: {DashboardGen.Application, []},
+      extra_applications: [:logger, :runtime_tools]
+    ]
+  end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
+
+  defp deps do
+    [
+      {:phoenix, "~> 1.7.10"},
+      {:phoenix_ecto, "~> 4.4"},
+      {:ecto_sql, "~> 3.10"},
+      {:postgrex, ">= 0.0.0"},
+      {:phoenix_live_view, "~> 0.20"},
+      {:phoenix_html, "~> 3.3"},
+      {:phoenix_live_dashboard, "~> 0.8"},
+      {:esbuild, "~> 0.7", runtime: Mix.env() == :dev},
+      {:tailwind, "~> 0.2", runtime: Mix.env() == :dev},
+      {:floki, ">= 0.34.0", only: :test},
+      {:telemetry_metrics, "~> 0.6"},
+      {:telemetry_poller, "~> 1.0"},
+      {:gettext, "~> 0.22"},
+      {:jason, "~> 1.4"},
+      {:plug_cowboy, "~> 2.6"},
+      {:nimble_csv, "~> 1.2"},
+      {:vega_lite, "~> 0.1"},
+      {:openai, "~> 0.5"},
+      {:dotenvy, "~> 0.8"}
+    ]
+  end
+
+  defp aliases do
+    [
+      setup: ["deps.get", "ecto.setup", "cmd --cd assets npm install"],
+      "assets.deploy": [
+        "tailwind default --minify",
+        "esbuild default --minify",
+        "phx.digest"
+      ]
+    ]
+  end
+end

--- a/dashboard_gen/priv/repo/migrations/20250714183131_create_dashboards.exs
+++ b/dashboard_gen/priv/repo/migrations/20250714183131_create_dashboards.exs
@@ -1,0 +1,16 @@
+defmodule DashboardGen.Repo.Migrations.CreateDashboards do
+  use Ecto.Migration
+
+  def change do
+    create table(:dashboards) do
+      add :slug, :string
+      add :prompt, :text
+      add :response_json, :text
+      add :insight_text, :text
+
+      timestamps()
+    end
+
+    create unique_index(:dashboards, [:slug])
+  end
+end

--- a/dashboard_gen/test/support/conn_case.ex
+++ b/dashboard_gen/test/support/conn_case.ex
@@ -1,0 +1,28 @@
+defmodule DashboardGenWeb.ConnCase do
+  @moduledoc """
+  This module defines the test case to be used by
+  tests that require setting up a connection.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      import Plug.Conn
+      import Phoenix.ConnTest
+      alias DashboardGenWeb.Router.Helpers, as: Routes
+
+      @endpoint DashboardGenWeb.Endpoint
+    end
+  end
+
+  setup tags do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(DashboardGen.Repo)
+
+    unless tags[:async] do
+      Ecto.Adapters.SQL.Sandbox.mode(DashboardGen.Repo, {:shared, self()})
+    end
+
+    {:ok, conn: Phoenix.ConnTest.build_conn()}
+  end
+end

--- a/dashboard_gen/test/support/data_case.ex
+++ b/dashboard_gen/test/support/data_case.ex
@@ -1,0 +1,23 @@
+defmodule DashboardGen.DataCase do
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      alias DashboardGen.Repo
+      import Ecto
+      import Ecto.Changeset
+      import Ecto.Query
+      import DashboardGen.DataCase
+    end
+  end
+
+  setup tags do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(DashboardGen.Repo)
+
+    unless tags[:async] do
+      Ecto.Adapters.SQL.Sandbox.mode(DashboardGen.Repo, {:shared, self()})
+    end
+
+    :ok
+  end
+end

--- a/dashboard_gen/test/test_helper.exs
+++ b/dashboard_gen/test/test_helper.exs
@@ -1,0 +1,2 @@
+ExUnit.start()
+Ecto.Adapters.SQL.Sandbox.mode(DashboardGen.Repo, :manual)


### PR DESCRIPTION
## Summary
- scaffold a new Phoenix 1.7 LiveView project `dashboard_gen`
- add GPT helper module using OpenAI API
- configure tailwind, esbuild, and .env loading
- set up Ecto repo and migrations for dashboards

## Testing
- `mix format`
- `mix test` *(fails: Hex install prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68754c1a77a48331809f4799781cedb2