### PR TITLE
Add Petal Components dashboard layout

### DIFF
--- a/dashboard_gen/assets/css/app.css
+++ b/dashboard_gen/assets/css/app.css
@@ -1,3 +1,5 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@import "../../deps/petal_components/assets/petal_components.css";

--- a/dashboard_gen/lib/dashboard_gen_web.ex
+++ b/dashboard_gen/lib/dashboard_gen_web.ex
@@ -11,6 +11,7 @@ defmodule DashboardGenWeb do
   def html do
     quote do
       use Phoenix.Component
+      use PetalComponents
       import Phoenix.HTML
       import DashboardGenWeb.Gettext
       alias DashboardGenWeb.Router.Helpers, as: Routes

--- a/dashboard_gen/lib/dashboard_gen_web/components/layouts/dashboard.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/components/layouts/dashboard.html.heex
@@ -1,0 +1,20 @@
+<div class="flex min-h-screen">
+  <aside class="w-60 bg-gray-800 text-white p-4 space-y-2">
+    <nav class="flex flex-col space-y-2">
+      <.link navigate={~p"/"} class="hover:underline">Dashboard</.link>
+      <.link navigate={~p"/saved"} class="hover:underline">Saved Views</.link>
+      <.link navigate={~p"/settings"} class="hover:underline">Settings</.link>
+    </nav>
+  </aside>
+
+  <div class="flex-1 flex flex-col">
+    <header class="p-4 bg-gray-100 border-b">
+      <h1 class="text-xl font-semibold">DashboardGen</h1>
+    </header>
+
+    <main class="flex-1 overflow-y-auto p-4">
+      <%= @inner_content %>
+    </main>
+  </div>
+</div>
+

--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
@@ -1,16 +1,29 @@
 defmodule DashboardGenWeb.DashboardLive do
-  use DashboardGenWeb, :live_view
+  use DashboardGenWeb, :live_view, layout: {DashboardGenWeb.Layouts, :dashboard}
 
   alias DashboardGen.GPT
+  require Logger
 
+  @impl true
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, query: "", result: nil)}
+    {:ok, assign(socket, query: "", chart_json: nil, loading: false)}
   end
 
+  @impl true
   def handle_event("submit", %{"query" => query}, socket) do
+    send(self(), {:run_query, query})
+    {:noreply, assign(socket, query: query, loading: true)}
+  end
+
+  @impl true
+  def handle_info({:run_query, query}, socket) do
     case GPT.ask(query) do
-      {:ok, json} -> {:noreply, assign(socket, result: json, query: query)}
-      {:error, reason} -> {:noreply, put_flash(socket, :error, "#{inspect(reason)}")}
+      {:ok, json} ->
+        {:noreply, assign(socket, chart_json: json, loading: false)}
+
+      {:error, reason} ->
+        Logger.error("GPT error: #{inspect(reason)}")
+        {:noreply, assign(socket, loading: false)}
     end
   end
 end

--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
@@ -1,10 +1,17 @@
-<div class="container mx-auto p-4">
-  <.form let={f} for={:query} phx-submit="submit">
-    <%= text_input f, :query, value: @query, class: "border p-2 w-full" %>
-    <%= submit "Run", class: "mt-2 bg-blue-500 text-white px-4 py-2" %>
-  </.form>
+<% form = to_form(%{"query" => @query}, as: :query) %>
 
-  <%= if @result do %>
-    <pre class="mt-4 bg-gray-100 p-2"><%= Jason.encode!(@result, pretty: true) %></pre>
-  <% end %>
+<.form for={form} phx-submit="submit" class="space-y-4">
+  <.input field={form[:query]} placeholder="Ask for a dashboard" class="w-full" />
+  <.button type="submit" phx-disable-with="Loading..." class="w-full">Run</.button>
+</.form>
+
+<div :if={@loading} class="mt-4">Loading...</div>
+
+<div id="chart" class="mt-4 h-64 bg-gray-200 flex items-center justify-center">
+  Chart will render here
 </div>
+
+<pre :if={@chart_json} class="mt-4 bg-gray-100 p-2 text-xs overflow-auto">
+  <%= Jason.encode!(@chart_json, pretty: true) %>
+</pre>
+

--- a/dashboard_gen/mix.exs
+++ b/dashboard_gen/mix.exs
@@ -44,7 +44,8 @@ defmodule DashboardGen.MixProject do
       {:nimble_csv, "~> 1.2"},
       {:vega_lite, "~> 0.1"},
       {:openai, "~> 0.5"},
-      {:dotenvy, "~> 0.8"}
+      {:dotenvy, "~> 0.8"},
+      {:petal_components, "~> 0.17"}
     ]
   end
 


### PR DESCRIPTION
## Summary
- add `petal_components` dependency
- import Petal CSS into Tailwind build
- enable Petal Components in `DashboardGenWeb`
- create dashboard layout with sidebar and header
- update live view to use Petal Components and show loading/JSON

## Testing
- `mix deps.get` *(fails: Could not install Hex)*
- `mix test` *(fails: Mix requires the Hex package manager)*

------
https://chatgpt.com/codex/tasks/task_e_68758dff61e88331aa30bd60a8838dc3