### PR TITLE
Fix missing Phoenix LiveView macro

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web.ex
+++ b/dashboard_gen/lib/dashboard_gen_web.ex
@@ -11,7 +11,31 @@ defmodule DashboardGenWeb do
   def html do
     quote do
       use Phoenix.Component
+      unquote(html_helpers())
+    end
+  end
+
+  def live_view do
+    quote do
+      use Phoenix.LiveView,
+        layout: {DashboardGenWeb.Layouts, :root}
+
+      unquote(html_helpers())
+    end
+  end
+
+  def live_component do
+    quote do
+      use Phoenix.LiveComponent
+
+      unquote(html_helpers())
+    end
+  end
+
+  defp html_helpers do
+    quote do
       import Phoenix.HTML
+      import Phoenix.LiveView.Helpers
       import DashboardGenWeb.Gettext
       alias DashboardGenWeb.Router.Helpers, as: Routes
     end

--- a/dashboard_gen/lib/dashboard_gen_web/gettext.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/gettext.ex
@@ -1,3 +1,3 @@
 defmodule DashboardGenWeb.Gettext do
-  use Gettext, otp_app: :dashboard_gen
+  use Gettext.Backend, otp_app: :dashboard_gen
 end

--- a/dashboard_gen/mix.exs
+++ b/dashboard_gen/mix.exs
@@ -7,7 +7,7 @@ defmodule DashboardGen.MixProject do
       version: "0.1.0",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
-      compilers: [:phoenix] ++ Mix.compilers(),
+      compilers: Mix.compilers(),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps()


### PR DESCRIPTION
## Summary
- implement `live_view` and `live_component` helpers
- use updated `Gettext.Backend`
- remove deprecated `:phoenix` compiler entry

## Testing
- `mix test` *(fails: Hex package manager cannot install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687552738df083318bee97a93345882a