### PR TITLE
Implement CSVLoader with sample marketing data

### DIFF
--- a/dashboard_gen/lib/dashboard_gen/csv_loader.ex
+++ b/dashboard_gen/lib/dashboard_gen/csv_loader.ex
@@ -1,0 +1,56 @@
+defmodule DashboardGen.CSVLoader do
+  @moduledoc """
+  Utilities for loading CSV files located under `priv/data`.
+
+  The `load/1` function returns a list of maps keyed by the CSV headers.
+  Headers are normalised by trimming whitespace and downcasing.
+  """
+
+  alias NimbleCSV.RFC4180, as: CSV
+
+  @data_path Path.join(:code.priv_dir(:dashboard_gen), "data")
+
+  @doc """
+  Reads the given CSV file from `priv/data` and returns the parsed rows as a
+  list of maps.
+  """
+  @spec load(String.t()) :: [map()]
+  def load(filename) when is_binary(filename) do
+    filename
+    |> build_path()
+    |> File.stream!()
+    |> CSV.parse_stream()
+    |> Enum.to_list()
+    |> to_maps()
+  end
+
+  @doc """
+  Lists the available CSV data sources under `priv/data`.
+  """
+  @spec available_data_sources() :: [String.t()]
+  def available_data_sources do
+    case File.ls(@data_path) do
+      {:ok, files} -> Enum.filter(files, &String.ends_with?(&1, ".csv"))
+      {:error, _} -> []
+    end
+  end
+
+  defp build_path(filename), do: Path.join(@data_path, filename)
+
+  defp to_maps([]), do: []
+  defp to_maps([headers | rows]) do
+    headers = Enum.map(headers, &normalize_header/1)
+
+    Enum.map(rows, fn row ->
+      headers
+      |> Enum.zip(row)
+      |> Map.new()
+    end)
+  end
+
+  defp normalize_header(hdr) do
+    hdr
+    |> String.trim()
+    |> String.downcase()
+  end
+end

--- a/dashboard_gen/priv/data/mock_marketing_data.csv
+++ b/dashboard_gen/priv/data/mock_marketing_data.csv
@@ -1,0 +1,4 @@
+campaign_name,channel,impressions,clicks,spend,conversions
+Reverse-engineered local product,LinkedIn,24961,2682,1320,320
+Advanced synergy,Twitter,10000,120,500,33
+Optimized brand,Facebook,50000,1230,3400,600


### PR DESCRIPTION
## Summary
- add CSV parsing helpers
- include a sample `mock_marketing_data.csv`

## Testing
- `mix deps.get` *(fails: could not establish SSL tunnel)*
- `mix compile` *(fails: Hex must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_687593ca22248331aa272c824dcbdf34