### PR TITLE
Fix missing live_view macro

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web.ex
+++ b/dashboard_gen/lib/dashboard_gen_web.ex
@@ -8,13 +8,28 @@ defmodule DashboardGenWeb do
     end
   end
 
-  def html do
+  defp html_helpers do
     quote do
       use Phoenix.Component
       use PetalComponents
       import Phoenix.HTML
       import DashboardGenWeb.Gettext
       alias DashboardGenWeb.Router.Helpers, as: Routes
+    end
+  end
+
+  def html do
+    quote do
+      unquote(html_helpers())
+    end
+  end
+
+  def live_view do
+    quote do
+      use Phoenix.LiveView,
+        layout: {DashboardGenWeb.Layouts, :root}
+
+      unquote(html_helpers())
     end
   end
 

--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
@@ -1,5 +1,6 @@
 defmodule DashboardGenWeb.DashboardLive do
-  use DashboardGenWeb, :live_view, layout: {DashboardGenWeb.Layouts, :dashboard}
+  use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :dashboard}
+  use DashboardGenWeb, :html
 
   alias DashboardGen.GPT
   require Logger


### PR DESCRIPTION
## Summary
- define `live_view` and `html_helpers` macros for Phoenix
- update DashboardLive to use Phoenix.LiveView directly

## Testing
- `mix compile` *(fails: Mix requires Hex to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687596005f488331884d22525e648b21