### PR TITLE
Fix gettext deprecation and link conflict

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web.ex
+++ b/dashboard_gen/lib/dashboard_gen_web.ex
@@ -3,7 +3,7 @@ defmodule DashboardGenWeb do
     quote do
       use Phoenix.Controller, namespace: DashboardGenWeb
       import Plug.Conn
-      import DashboardGenWeb.Gettext
+      use Gettext, backend: DashboardGenWeb.Gettext
       alias DashboardGenWeb.Router.Helpers, as: Routes
     end
   end
@@ -13,7 +13,7 @@ defmodule DashboardGenWeb do
       use Phoenix.Component
       use PetalComponents
       import Phoenix.HTML
-      import DashboardGenWeb.Gettext
+      use Gettext, backend: DashboardGenWeb.Gettext
       alias DashboardGenWeb.Router.Helpers, as: Routes
     end
   end
@@ -43,7 +43,7 @@ defmodule DashboardGenWeb do
   def channel do
     quote do
       use Phoenix.Channel
-      import DashboardGenWeb.Gettext
+      use Gettext, backend: DashboardGenWeb.Gettext
     end
   end
 

--- a/dashboard_gen/lib/dashboard_gen_web/components/layouts/dashboard.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/components/layouts/dashboard.html.heex
@@ -1,9 +1,9 @@
 <div class="flex min-h-screen">
   <aside class="w-60 bg-gray-800 text-white p-4 space-y-2">
     <nav class="flex flex-col space-y-2">
-      <.link navigate={~p"/"} class="hover:underline">Dashboard</.link>
-      <.link navigate={~p"/saved"} class="hover:underline">Saved Views</.link>
-      <.link navigate={~p"/settings"} class="hover:underline">Settings</.link>
+      <Phoenix.Component.link navigate={~p"/"} class="hover:underline">Dashboard</Phoenix.Component.link>
+      <Phoenix.Component.link navigate={~p"/saved"} class="hover:underline">Saved Views</Phoenix.Component.link>
+      <Phoenix.Component.link navigate={~p"/settings"} class="hover:underline">Settings</Phoenix.Component.link>
     </nav>
   </aside>
 

--- a/dashboard_gen/lib/dashboard_gen_web/gettext.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/gettext.ex
@@ -1,3 +1,7 @@
 defmodule DashboardGenWeb.Gettext do
-  use Gettext, otp_app: :dashboard_gen
+  @moduledoc false
+
+  # Use the Gettext backend behaviour. This replaces the deprecated
+  # `use Gettext` with the `otp_app:` option.
+  use Gettext.Backend, otp_app: :dashboard_gen
 end


### PR DESCRIPTION
## Summary
- update Gettext backend usage
- explicitly use `Phoenix.Component.link` in dashboard layout to avoid conflict

## Testing
- `mix compile` *(fails: Mix requires Hex and can't download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6875ab145fb48331a07b34b9e9159427