### PR TITLE
Fix Phoenix compile errors

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web.ex
+++ b/dashboard_gen/lib/dashboard_gen_web.ex
@@ -5,6 +5,8 @@ defmodule DashboardGenWeb do
       import Plug.Conn
       use Gettext, backend: DashboardGenWeb.Gettext
       alias DashboardGenWeb.Router.Helpers, as: Routes
+
+      unquote(verified_routes())
     end
   end
 
@@ -12,9 +14,12 @@ defmodule DashboardGenWeb do
     quote do
       use Phoenix.Component
       use PetalComponents
-      import Phoenix.HTML
+      use Phoenix.HTML
       use Gettext, backend: DashboardGenWeb.Gettext
+      alias Phoenix.LiveView.JS
       alias DashboardGenWeb.Router.Helpers, as: Routes
+
+      unquote(verified_routes())
     end
   end
 
@@ -48,6 +53,15 @@ defmodule DashboardGenWeb do
   end
 
   def static_paths, do: ["assets", "favicon.ico", "robots.txt"]
+
+  def verified_routes do
+    quote do
+      use Phoenix.VerifiedRoutes,
+        endpoint: DashboardGenWeb.Endpoint,
+        router: DashboardGenWeb.Router,
+        statics: DashboardGenWeb.static_paths()
+    end
+  end
 
   defmacro __using__(which) when is_atom(which) do
     apply(__MODULE__, which, [])

--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
@@ -1,7 +1,7 @@
 <% form = to_form(%{"query" => @query}, as: :query) %>
 
 <.form for={form} phx-submit="submit" class="space-y-4">
-  <.input field={form[:query]} placeholder="Ask for a dashboard" class="w-full" />
+  <%= text_input form, :query, placeholder: "Ask for a dashboard", class: "w-full" %>
   <.button type="submit" phx-disable-with="Loading..." class="w-full">Run</.button>
 </.form>
 


### PR DESCRIPTION
## Summary
- enable VerifiedRoutes and use Phoenix.HTML helpers
- replace `<.input>` with `text_input` so the dashboard live view renders

## Testing
- `mix compile` *(fails: Mix requires Hex)*

------
https://chatgpt.com/codex/tasks/task_e_6875ae1aa2cc8331ae2b60253df7b7c1