### PR TITLE
Fix runtime SECRET_KEY_BASE error

### DIFF
--- a/dashboard_gen/config/runtime.exs
+++ b/dashboard_gen/config/runtime.exs
@@ -5,9 +5,15 @@ if File.exists?(Path.expand("../.env", __DIR__)) do
   Dotenvy.source!(Path.expand("../.env", __DIR__))
 end
 
-config :dashboard_gen, DashboardGenWeb.Endpoint,
-  server: true,
-  url: [host: System.get_env("PHX_HOST", "example.com"), port: 443],
-  secret_key_base: System.fetch_env!("SECRET_KEY_BASE")
+if config_env() == :prod do
+  config :dashboard_gen, DashboardGenWeb.Endpoint,
+    server: true,
+    url: [host: System.get_env("PHX_HOST", "example.com"), port: 443],
+    secret_key_base: System.fetch_env!("SECRET_KEY_BASE")
 
-config :openai, api_key: System.fetch_env!("OPENAI_API_KEY")
+  config :openai, api_key: System.fetch_env!("OPENAI_API_KEY")
+else
+  if api_key = System.get_env("OPENAI_API_KEY") do
+    config :openai, api_key: api_key
+  end
+end


### PR DESCRIPTION
## Summary
- avoid raising when SECRET_KEY_BASE/OPENAI_API_KEY are unset in non-prod

## Testing
- `mix test` *(fails: Mix requires the Hex package manager)*

------
https://chatgpt.com/codex/tasks/task_e_6875b049db808331a8fb6792ce48220c