### PR TITLE
Fix Phoenix compiler entry

### DIFF
--- a/dashboard_gen/mix.exs
+++ b/dashboard_gen/mix.exs
@@ -7,7 +7,7 @@ defmodule DashboardGen.MixProject do
       version: "0.1.0",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
-      compilers: [:phoenix] ++ Mix.compilers(),
+      compilers: Mix.compilers(),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps()


### PR DESCRIPTION
## Summary
- remove `:phoenix` from mix compilers list

## Testing
- `mix compile` *(fails: could not install Hex)*

------
https://chatgpt.com/codex/tasks/task_e_68766368a8ac833186b10fa994f215e1