### PR TITLE
Fix Telemetry Poller optional start

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/telemetry.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/telemetry.ex
@@ -7,12 +7,20 @@ defmodule DashboardGenWeb.Telemetry do
   end
 
   def init(_arg) do
-    children = [
-      {Telemetry.Poller, measurements: periodic_measurements(), period: 10_000},
-      {Telemetry.Metrics.ConsoleReporter, metrics: metrics()}
-    ]
+    children =
+      []
+      |> maybe_add_poller()
+      |> List.insert_at(-1, {Telemetry.Metrics.ConsoleReporter, metrics: metrics()})
 
     Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  defp maybe_add_poller(children) do
+    if Code.ensure_loaded?(Telemetry.Poller) do
+      [{Telemetry.Poller, measurements: periodic_measurements(), period: 10_000} | children]
+    else
+      children
+    end
   end
 
   def metrics do


### PR DESCRIPTION
## Summary
- avoid startup crash when Telemetry.Poller is unavailable by checking for the module before adding it to the supervision tree

## Testing
- `mix compile` *(fails: Could not install Hex)*

------
https://chatgpt.com/codex/tasks/task_e_687665ed9f148331b470d07c65eec021