### PR TITLE
Fix watchers configuration

### DIFF
--- a/dashboard_gen/config/dev.exs
+++ b/dashboard_gen/config/dev.exs
@@ -19,8 +19,8 @@ config :dashboard_gen, DashboardGenWeb.Endpoint,
   debug_errors: true,
   secret_key_base: "DEV_SECRET_KEY_BASE",
   watchers: [
-    esbuild: {Esbuild, :install_and_run, [~w(--sourcemap=inline --watch)]},
-    tailwind: {Tailwind, :install_and_run, [~w(--watch)]}
+    esbuild: {Esbuild, :install_and_run, [:default, ~w(--sourcemap=inline --watch)]},
+    tailwind: {Tailwind, :install_and_run, [:default, ~w(--watch)]}
   ]
 
 # Watch static and templates for browser reloading.


### PR DESCRIPTION
## Summary
- fix esbuild & tailwind watchers in dev config

## Testing
- `mix test` *(fails: could not install Hex)*

------
https://chatgpt.com/codex/tasks/task_e_687668c6168c8331aee7531843bedd68