### PR TITLE
Fix esbuild config version

### DIFF
--- a/dashboard_gen/config/config.exs
+++ b/dashboard_gen/config/config.exs
@@ -10,7 +10,10 @@ config :dashboard_gen, DashboardGenWeb.Endpoint,
   live_view: [signing_salt: "SA1tSaLt"]
 
 config :esbuild,
-  version: "0.7.0",
+  # Bump the bundled esbuild version to a modern release since 0.7.0 is no
+  # longer distributed via npm. 0.17.11 is compatible with the current
+  # `esbuild` mix dependency and is available for download.
+  version: "0.17.11",
   default: [
     args: ~w(js/app.js --bundle --target=es2017 --outdir=../priv/static/assets),
     cd: Path.expand("../assets", __DIR__),


### PR DESCRIPTION
## Summary
- use supported esbuild version instead of outdated 0.7.0

## Testing
- `mix local.hex --force` *(fails: could not establish SSL tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_68766cc730788331b477168d471c3a77