### PR TITLE
Fix missing Phoenix JS import

### DIFF
--- a/dashboard_gen/assets/js/phx.js
+++ b/dashboard_gen/assets/js/phx.js
@@ -1,0 +1,16 @@
+import "phoenix_html";
+import {Socket} from "phoenix";
+import {LiveSocket} from "phoenix_live_view";
+
+// Initialize LiveView socket with CSRF token from meta tag
+const csrfToken = document.querySelector("meta[name='csrf-token']")?.getAttribute("content");
+const liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}});
+
+// Connect if there are any LiveViews on the page
+liveSocket.connect();
+
+// Expose liveSocket on window for web console debug logs and latency simulation:
+// >> liveSocket.enableDebug()
+// >> liveSocket.enableLatencySim(1000)
+// >> liveSocket.disableLatencySim()
+window.liveSocket = liveSocket;


### PR DESCRIPTION
## Summary
- add missing `phx.js` which sets up Phoenix LiveView

## Testing
- `mix format`
- `mix compile` *(fails: Could not fetch Hex)*

------
https://chatgpt.com/codex/tasks/task_e_68766f5af468833184b94b1f8a58599b