### PR TITLE
Remove Petal Components dependency

### DIFF
--- a/dashboard_gen/assets/css/app.css
+++ b/dashboard_gen/assets/css/app.css
@@ -2,4 +2,3 @@
 @tailwind components;
 @tailwind utilities;
 
-@import "../../deps/petal_components/assets/petal_components.css";

--- a/dashboard_gen/lib/dashboard_gen_web.ex
+++ b/dashboard_gen/lib/dashboard_gen_web.ex
@@ -13,7 +13,6 @@ defmodule DashboardGenWeb do
   defp html_helpers do
     quote do
       use Phoenix.Component
-      use PetalComponents
       use Phoenix.HTML
       use Gettext, backend: DashboardGenWeb.Gettext
       alias Phoenix.LiveView.JS

--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
@@ -1,9 +1,7 @@
-<% form = to_form(%{"query" => @query}, as: :query) %>
-
-<.form for={form} phx-submit="submit" class="space-y-4">
-  <%= text_input form, :query, placeholder: "Ask for a dashboard", class: "w-full" %>
-  <.button type="submit" phx-disable-with="Loading..." class="w-full">Run</.button>
-</.form>
+<form phx-submit="submit" class="space-y-4">
+  <input type="text" name="query[query]" value={@query} placeholder="Ask for a dashboard" class="w-full" />
+  <button type="submit" phx-disable-with="Loading..." class="w-full bg-blue-600 text-white px-4 py-2 rounded">Run</button>
+</form>
 
 <div :if={@loading} class="mt-4">Loading...</div>
 


### PR DESCRIPTION
## Summary
- remove `use PetalComponents` and replace Petal UI elements with regular HTML
- drop the Petal CSS import

## Testing
- `mix deps.clean petal_components` *(fails: Hex unavailable)*
- `mix deps.get` *(fails: Hex unavailable)*
- `mix compile` *(fails: Hex unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6877a721f95c83318614da0ee8699651