### PR TITLE
Add placeholder pages to silence router warnings

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/saved_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/saved_live.ex
@@ -1,0 +1,9 @@
+defmodule DashboardGenWeb.SavedLive do
+  use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :dashboard}
+  use DashboardGenWeb, :html
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, :page_title, "Saved Views")}
+  end
+end

--- a/dashboard_gen/lib/dashboard_gen_web/live/saved_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/saved_live.html.heex
@@ -1,0 +1,4 @@
+<div>
+  <h2 class="text-lg font-semibold mb-4">Saved Views</h2>
+  <p>This page will list saved dashboards in the future.</p>
+</div>

--- a/dashboard_gen/lib/dashboard_gen_web/live/settings_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/settings_live.ex
@@ -1,0 +1,9 @@
+defmodule DashboardGenWeb.SettingsLive do
+  use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :dashboard}
+  use DashboardGenWeb, :html
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, :page_title, "Settings")}
+  end
+end

--- a/dashboard_gen/lib/dashboard_gen_web/live/settings_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/settings_live.html.heex
@@ -1,0 +1,4 @@
+<div>
+  <h2 class="text-lg font-semibold mb-4">Settings</h2>
+  <p>This page will contain application settings.</p>
+</div>

--- a/dashboard_gen/lib/dashboard_gen_web/router.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/router.ex
@@ -16,5 +16,7 @@ defmodule DashboardGenWeb.Router do
     pipe_through(:browser)
 
     live("/", DashboardLive)
+    live("/saved", SavedLive)
+    live("/settings", SettingsLive)
   end
 end


### PR DESCRIPTION
## Summary
- add SavedLive and SettingsLive placeholder pages
- wire new live routes

## Testing
- `mix test` *(fails: Mix requires the Hex package manager)*

------
https://chatgpt.com/codex/tasks/task_e_6877a93821b483319bae879bab6097e1