### PR TITLE
Add GPT client module for OpenAI chart specs

### DIFF
--- a/dashboard_gen/.env.example
+++ b/dashboard_gen/.env.example
@@ -1,0 +1,3 @@
+# Environment variables for DashboardGen
+# Copy this file to .env and fill in your secrets
+OPENAI_API_KEY=

--- a/dashboard_gen/lib/dashboard_gen/gpt_client.ex
+++ b/dashboard_gen/lib/dashboard_gen/gpt_client.ex
@@ -1,0 +1,78 @@
+defmodule DashboardGen.GPTClient do
+  @moduledoc """
+  Client for communicating with the OpenAI chat completions API.
+
+  Provides a single `get_chart_spec/1` function which sends a prompt to
+  OpenAI and expects a JSON response describing charts.
+  """
+
+  @openai_url "https://api.openai.com/v1/chat/completions"
+
+  @doc """
+  Sends the given prompt to the OpenAI API and returns the decoded chart
+  specification on success.
+  """
+  @spec get_chart_spec(String.t()) :: {:ok, map()} | {:error, String.t()}
+  def get_chart_spec(prompt) when is_binary(prompt) do
+    api_key = fetch_api_key!()
+
+    body = %{
+      model: "gpt-4",
+      messages: [
+        %{role: "system", content: default_system_prompt()},
+        %{role: "user", content: prompt}
+      ]
+    }
+
+    headers = [
+      {"authorization", "Bearer #{api_key}"},
+      {"content-type", "application/json"}
+    ]
+
+    with {:ok, %Req.Response{status: 200, body: %{"choices" => choices}}} <-
+           Req.post(@openai_url, json: body, headers: headers),
+         %{"message" => %{"content" => content}} <- List.first(choices),
+         {:ok, decoded} <- Jason.decode(content),
+         true <- Map.has_key?(decoded, "charts") do
+      {:ok, decoded}
+    else
+      {:error, %Req.Response{body: body}} ->
+        {:error, inspect(body)}
+
+      {:error, reason} ->
+        {:error, inspect(reason)}
+
+      _ ->
+        {:error, "Invalid chart spec"}
+    end
+  end
+
+  @doc """
+  Returns the default system prompt instructing the model to reply with a
+  strict JSON schema.
+  """
+  @spec default_system_prompt() :: String.t()
+  def default_system_prompt do
+    """
+    You are ChartGPT. Respond only with valid JSON following this schema:
+
+    {
+      "charts": [
+        {
+          "type": "bar",
+          "title": "title text",
+          "x": "x field",
+          "y": ["y field"],
+          "data_source": "file.csv"
+        }
+      ]
+    }
+    """
+    |> String.trim()
+  end
+
+  defp fetch_api_key! do
+    System.get_env("OPENAI_API_KEY") ||
+      raise "OPENAI_API_KEY environment variable is missing"
+  end
+end

--- a/dashboard_gen/mix.exs
+++ b/dashboard_gen/mix.exs
@@ -17,7 +17,7 @@ defmodule DashboardGen.MixProject do
   def application do
     [
       mod: {DashboardGen.Application, []},
-      extra_applications: [:logger, :runtime_tools]
+      extra_applications: [:logger, :runtime_tools, :req]
     ]
   end
 
@@ -44,7 +44,8 @@ defmodule DashboardGen.MixProject do
       {:nimble_csv, "~> 1.2"},
       {:vega_lite, "~> 0.1"},
       {:openai, "~> 0.5"},
-      {:dotenvy, "~> 0.8"}
+      {:dotenvy, "~> 0.8"},
+      {:req, "~> 0.4"}
     ]
   end
 


### PR DESCRIPTION
## Summary
- add new `DashboardGen.GPTClient` module for querying OpenAI
- expose `get_chart_spec/1` and helper `default_system_prompt/0`
- add `req` dependency and start its application
- provide `.env.example` for API keys

## Testing
- `mix format`
- `mix test` *(fails: requires hex install)*

------
https://chatgpt.com/codex/tasks/task_e_6877aceeb35c8331ab53ea34e1b64ec2