### PR TITLE
Fix DashboardLive query handling

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
@@ -11,9 +11,15 @@ defmodule DashboardGenWeb.DashboardLive do
   end
 
   @impl true
-  def handle_event("submit", %{"query" => query}, socket) do
+  def handle_event("submit", %{"query" => query}, socket) when is_binary(query) do
     send(self(), {:run_query, query})
     {:noreply, assign(socket, query: query, loading: true)}
+  end
+
+  @impl true
+  def handle_event("submit", params, socket) do
+    Logger.warning("submit event missing query: #{inspect(params)}")
+    {:noreply, socket}
   end
 
   @impl true


### PR DESCRIPTION
## Summary
- assign query string from form params when handling `submit`
- warn and ignore submit events missing the `query` field

## Testing
- `mix format`
- `mix compile --warnings-as-errors` *(fails: Mix requires the Hex package manager to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6877bbb30c6c833189826d1b0b3baa62