### PR TITLE
Add chart generation dashboard

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
@@ -2,35 +2,102 @@ defmodule DashboardGenWeb.DashboardLive do
   use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :dashboard}
   use DashboardGenWeb, :html
 
-  alias DashboardGen.GPT
-  require Logger
+  alias DashboardGen.GPTClient
+  alias NimbleCSV.RFC4180, as: CSV
+  alias Contex.{Dataset, Plot, BarChart}
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, query: "", chart_json: nil, loading: false)}
+    {:ok, assign(socket, prompt: "", chart_svg: nil, loading: false)}
   end
 
   @impl true
-  def handle_event("submit", %{"query" => query}, socket) when is_binary(query) do
-    send(self(), {:run_query, query})
-    {:noreply, assign(socket, query: query, loading: true)}
+  def handle_event("generate", %{"prompt" => prompt}, socket) do
+    send(self(), {:generate_chart, prompt})
+    {:noreply, assign(socket, prompt: prompt, loading: true, chart_svg: nil)}
   end
 
   @impl true
-  def handle_event("submit", params, socket) do
-    Logger.warning("submit event missing query: #{inspect(params)}")
-    {:noreply, socket}
-  end
-
-  @impl true
-  def handle_info({:run_query, query}, socket) do
-    case GPT.ask(query) do
-      {:ok, json} ->
-        {:noreply, assign(socket, chart_json: json, loading: false)}
+  def handle_info({:generate_chart, prompt}, socket) do
+    case GPTClient.get_chart_spec(prompt) do
+      {:ok, %{"charts" => [chart | _]}} ->
+        with {:ok, rows} <- load_csv(chart["data_source"]),
+             {:ok, dataset} <- build_dataset(rows, chart["x"], chart["y"]),
+             svg <- render_chart(dataset, chart) do
+          {:noreply, assign(socket, chart_svg: svg, loading: false)}
+        else
+          {:error, reason} ->
+            {:noreply,
+             socket
+             |> put_flash(:error, reason)
+             |> assign(loading: false)}
+        end
 
       {:error, reason} ->
-        Logger.error("GPT error: #{inspect(reason)}")
-        {:noreply, assign(socket, loading: false)}
+        {:noreply,
+         socket
+         |> put_flash(:error, reason)
+         |> assign(loading: false)}
     end
+  end
+
+  defp load_csv(filename) do
+    path = Path.join(:code.priv_dir(:dashboard_gen), "static/data/" <> filename)
+
+    if File.exists?(path) do
+      rows =
+        path
+        |> File.stream!()
+        |> CSV.parse_stream()
+        |> Enum.to_list()
+
+      case rows do
+        [] ->
+          {:ok, []}
+
+        [headers | data_rows] ->
+          headers = Enum.map(headers, &String.trim/1)
+
+          data =
+            Enum.map(data_rows, fn row ->
+              headers
+              |> Enum.zip(row)
+              |> Map.new()
+            end)
+
+          {:ok, data}
+      end
+    else
+      {:error, "CSV file not found: #{filename}"}
+    end
+  end
+
+  defp build_dataset(rows, x_field, y_fields) do
+    data =
+      Enum.map(rows, fn row ->
+        [Map.get(row, x_field) | Enum.map(y_fields, &parse_number(Map.get(row, &1)))]
+      end)
+
+    headers = [x_field | y_fields]
+    {:ok, Dataset.new(data, headers)}
+  end
+
+  defp parse_number(nil), do: nil
+
+  defp parse_number(val) when is_binary(val) do
+    case Float.parse(val) do
+      {num, _} -> num
+      :error -> val
+    end
+  end
+
+  defp parse_number(val), do: val
+
+  defp render_chart(dataset, %{"title" => title, "x" => x, "y" => y_fields}) do
+    mapping = %{category_col: x, value_cols: y_fields}
+
+    Plot.new(dataset, BarChart, mapping: mapping)
+    |> Plot.titles(title, nil)
+    |> Plot.to_svg()
   end
 end

--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
@@ -1,15 +1,14 @@
-<form phx-submit="submit" class="space-y-4">
-  <input type="text" name="query[query]" value={@query} placeholder="Ask for a dashboard" class="w-full" />
-  <button type="submit" phx-disable-with="Loading..." class="w-full bg-blue-600 text-white px-4 py-2 rounded">Run</button>
+<form phx-submit="generate" class="flex items-center space-x-2 mb-4">
+  <input type="text" name="prompt" value={@prompt} placeholder="Describe a chart" class="flex-1 border rounded px-2 py-1" />
+  <button type="submit" phx-disable-with="Generating..." class="px-4 py-1 bg-blue-600 text-white rounded">Generate</button>
 </form>
 
-<div :if={@loading} class="mt-4">Loading...</div>
+<%= if live_flash(@flash, :error) do %>
+  <div class="text-red-600 mb-2"><%= live_flash(@flash, :error) %></div>
+<% end %>
 
-<div id="chart" class="mt-4 h-64 bg-gray-200 flex items-center justify-center">
-  Chart will render here
+<div :if={@loading} class="mt-2 text-gray-500">Generating...</div>
+
+<div :if={@chart_svg} class="mt-6" phx-update="ignore">
+  <%= raw @chart_svg %>
 </div>
-
-<pre :if={@chart_json} class="mt-4 bg-gray-100 p-2 text-xs overflow-auto">
-  <%= Jason.encode!(@chart_json, pretty: true) %>
-</pre>
-

--- a/dashboard_gen/lib/dashboard_gen_web/router.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/router.ex
@@ -16,6 +16,7 @@ defmodule DashboardGenWeb.Router do
     pipe_through(:browser)
 
     live("/", DashboardLive)
+    live("/dashboard", DashboardLive)
     live("/saved", SavedLive)
     live("/settings", SettingsLive)
   end

--- a/dashboard_gen/mix.exs
+++ b/dashboard_gen/mix.exs
@@ -45,7 +45,8 @@ defmodule DashboardGen.MixProject do
       {:vega_lite, "~> 0.1"},
       {:openai, "~> 0.5"},
       {:dotenvy, "~> 0.8"},
-      {:req, "~> 0.4"}
+      {:req, "~> 0.4"},
+      {:contex, "~> 0.4.0"}
     ]
   end
 

--- a/dashboard_gen/priv/static/data/mock_marketing_data.csv
+++ b/dashboard_gen/priv/static/data/mock_marketing_data.csv
@@ -1,0 +1,4 @@
+campaign_name,channel,impressions,clicks,spend,conversions
+Reverse-engineered local product,LinkedIn,24961,2682,1320,320
+Advanced synergy,Twitter,10000,120,500,33
+Optimized brand,Facebook,50000,1230,3400,600


### PR DESCRIPTION
## Summary
- use Contex lib for charting
- create NL chart generation dashboard at `/dashboard`
- route `/dashboard` to the new LiveView
- ship mock marketing dataset under `priv/static/data`

## Testing
- `mix format mix.exs lib/dashboard_gen_web/router.ex`
- `mix test` *(fails: Mix requires Hex)*

------
https://chatgpt.com/codex/tasks/task_e_6877d5144b1c83318723d82cc9dbcc83