### PR TITLE
Fix LiveView chart container id

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
@@ -9,6 +9,6 @@
 
 <div :if={@loading} class="mt-2 text-gray-500">Generating...</div>
 
-<div :if={@chart_svg} class="mt-6" phx-update="ignore">
+<div :if={@chart_svg} id="chart-container" class="mt-6" phx-update="ignore">
   <%= raw @chart_svg %>
 </div>


### PR DESCRIPTION
## Summary
- fix `phx-update` usage by adding a required `id` to the chart div

## Testing
- `mix test` *(fails: Mix requires Hex to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6877e4f0765483318df7f6112641102e