### PR TITLE
Fix VegaLite error by moving rendering to client

### DIFF
--- a/dashboard_gen/assets/js/phx.js
+++ b/dashboard_gen/assets/js/phx.js
@@ -2,9 +2,25 @@ import "phoenix_html";
 import {Socket} from "phoenix";
 import {LiveSocket} from "phoenix_live_view";
 
+let Hooks = {};
+
+Hooks.VegaLiteChart = {
+  mounted() { this.renderChart(); },
+  updated() { this.renderChart(); },
+  renderChart() {
+    const spec = JSON.parse(this.el.dataset.spec || '{}');
+    if (window.vegaEmbed) {
+      window.vegaEmbed(this.el, spec, {actions: false});
+    }
+  }
+};
+
 // Initialize LiveView socket with CSRF token from meta tag
 const csrfToken = document.querySelector("meta[name='csrf-token']")?.getAttribute("content");
-const liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}});
+const liveSocket = new LiveSocket("/live", Socket, {
+  params: {_csrf_token: csrfToken},
+  hooks: Hooks
+});
 
 // Connect if there are any LiveViews on the page
 liveSocket.connect();

--- a/dashboard_gen/lib/dashboard_gen_web/components/layouts/root.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/components/layouts/root.html.heex
@@ -6,6 +6,9 @@
     <%= csrf_meta_tag() %>
     <%= live_title_tag assigns[:page_title] || "DashboardGen" %>
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
+    <script src="https://cdn.jsdelivr.net/npm/vega@5" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-lite@5" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-embed@6" defer></script>
   </head>
   <body>
     <%= @inner_content %>

--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
@@ -9,6 +9,5 @@
 
 <div :if={@loading} class="mt-2 text-gray-500">Generating...</div>
 
-<div :if={@chart_svg} id="chart-container" class="mt-6" phx-update="ignore">
-  <%= raw(@chart_svg || "") %>
+<div :if={@chart_spec} id="chart-container" class="mt-6" phx-hook="VegaLiteChart" phx-update="ignore" data-spec={@chart_spec}>
 </div>


### PR DESCRIPTION
## Summary
- fix dashboard liveview to send spec JSON instead of calling missing `Vl.to_svg`
- render Vega-Lite charts client-side with `vega-embed`
- include Vega scripts in the root layout

## Testing
- `mix format`
- `mix test` *(fails: Hex install required)*

------
https://chatgpt.com/codex/tasks/task_e_6877ea5f019c8331a201f6404613dae8