### PR TITLE
Allow custom port in Phoenix dev config

### DIFF
--- a/dashboard_gen/README.md
+++ b/dashboard_gen/README.md
@@ -17,5 +17,15 @@ end
 
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/dashboard_gen>.
+  be found at <https://hexdocs.pm/dashboard_gen>.
+
+## Running the app
+
+The development configuration now reads the HTTP port from the `PORT`
+environment variable. It defaults to `4000`. If that port is already in
+use, start the server on another port with:
+
+```bash
+PORT=4001 mix phx.server
+```
 

--- a/dashboard_gen/config/dev.exs
+++ b/dashboard_gen/config/dev.exs
@@ -12,8 +12,10 @@ config :dashboard_gen, DashboardGen.Repo,
 
 # For development, we disable any cache and enable
 # debugging and code reloading.
+port = String.to_integer(System.get_env("PORT") || "4000")
+
 config :dashboard_gen, DashboardGenWeb.Endpoint,
-  http: [ip: {127, 0, 0, 1}, port: 4000],
+  http: [ip: {127, 0, 0, 1}, port: port],
   check_origin: false,
   code_reloader: true,
   debug_errors: true,


### PR DESCRIPTION
## Summary
- allow environment variable to override the default dev port
- document how to run the app on an alternate port when 4000 is busy

## Testing
- `mix test` *(fails: requires hex to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6877f198622c833184f6432d7229bfae