### PR TITLE
Fix VegaLite encode usage

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
@@ -30,9 +30,9 @@ defmodule DashboardGenWeb.DashboardLive do
           VegaLite.new()
           |> VegaLite.data_from_values(data)
           |> VegaLite.mark(String.to_atom(chart_spec["type"]))
-          |> VegaLite.encode(:x, "x", type: :nominal)
-          |> VegaLite.encode(:y, "value", type: :quantitative)
-          |> VegaLite.encode(:color, "category", type: :nominal)
+          |> VegaLite.encode(:x, field: "x", type: :nominal)
+          |> VegaLite.encode(:y, field: "value", type: :quantitative)
+          |> VegaLite.encode(:color, field: "category", type: :nominal)
           |> VegaLite.title(chart_spec["title"])
 
         spec = VegaLite.to_spec(vl) |> Jason.encode!()


### PR DESCRIPTION
## Summary
- adjust `VegaLite.encode` usage to the 3-argument form expected by the library

## Testing
- `mix compile` *(fails: requires Hex package manager)*
- `mix test` *(fails: requires Hex package manager)*

------
https://chatgpt.com/codex/tasks/task_e_6877f9150b9c8331b73557d0c50ca349