### PR TITLE
Fix VegaLite chart options

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
@@ -33,7 +33,7 @@ defmodule DashboardGenWeb.DashboardLive do
           |> VegaLite.encode(:x, field: "x", type: :nominal)
           |> VegaLite.encode(:y, field: "value", type: :quantitative)
           |> VegaLite.encode(:color, field: "category", type: :nominal)
-          |> VegaLite.title(chart_spec["title"])
+          |> VegaLite.config(:title, chart_spec["title"])
 
         spec = VegaLite.to_spec(vl) |> Jason.encode!()
 


### PR DESCRIPTION
## Summary
- use `VegaLite.config/2` instead of removed `VegaLite.title/2`

## Testing
- `mix test` *(fails: could not install Hex)*

------
https://chatgpt.com/codex/tasks/task_e_6877fc40739c833193f1756517052783