### PR TITLE
Add CSV header mapping for GPT chart specs

### DIFF
--- a/dashboard_gen/lib/dashboard_gen/csv_header_mapper.ex
+++ b/dashboard_gen/lib/dashboard_gen/csv_header_mapper.ex
@@ -1,0 +1,32 @@
+defmodule DashboardGen.CSVHeaderMapper do
+  @moduledoc """
+  Provides utilities for translating raw CSV headers to the field
+  names expected by GPT generated chart specifications.
+  """
+
+  @mapping %{
+    "Month" => "campaign_name",
+    "Ad Spend" => "spend",
+    "Conversions" => "conversions"
+  }
+
+  @doc """
+  Remaps a list of CSV row maps using GPT field names.
+
+  ## Examples
+
+      iex> remap_headers([%{"campaign_name" => "Jan", "spend" => 1000}])
+      [%{"Month" => "Jan", "Ad Spend" => 1000}]
+  """
+  @spec remap_headers([map()]) :: [map()]
+  def remap_headers(rows) when is_list(rows) do
+    inverse = Map.new(@mapping, fn {gpt, raw} -> {raw, gpt} end)
+
+    Enum.map(rows, fn row ->
+      Enum.reduce(row, %{}, fn {key, value}, acc ->
+        Map.put(acc, Map.get(inverse, key, key), value)
+      end)
+    end)
+  end
+end
+

--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
@@ -4,6 +4,7 @@ defmodule DashboardGenWeb.DashboardLive do
 
   alias DashboardGen.GPTClient
   alias DashboardGen.CSVUtils
+  alias DashboardGen.CSVHeaderMapper
   alias VegaLite
 
   @impl true
@@ -24,7 +25,10 @@ defmodule DashboardGenWeb.DashboardLive do
         csv_path =
           Path.join(:code.priv_dir(:dashboard_gen), "static/data/" <> chart_spec["data_source"])
 
-        data = CSVUtils.melt_wide_to_long(csv_path, chart_spec["x"], chart_spec["y"])
+        raw_data =
+          CSVUtils.melt_wide_to_long(csv_path, chart_spec["x"], chart_spec["y"])
+
+        data = CSVHeaderMapper.remap_headers(raw_data)
 
         long_data =
           Enum.map(data, fn %{x: x, value: value, category: category} ->


### PR DESCRIPTION
## Summary
- implement `DashboardGen.CSVHeaderMapper` for translating raw CSV headers
- remap melted data before building VegaLite charts

## Testing
- `mix test` *(fails: Mix requires the Hex package manager)*

------
https://chatgpt.com/codex/tasks/task_e_687830bf5ab08331a438352b3f6d0524