### PR TITLE
Add CSV header mapping helper

### DIFF
--- a/dashboard_gen/lib/dashboard_gen/csv_header_mapper.ex
+++ b/dashboard_gen/lib/dashboard_gen/csv_header_mapper.ex
@@ -1,34 +1,48 @@
 defmodule DashboardGen.CSVHeaderMapper do
   @moduledoc """
-  Provides utilities for translating raw CSV headers to the field
-  names expected by GPT generated chart specifications.
+  Helper utilities for normalising GPT generated field names to the
+  headers used in our CSV datasets.
+
+  GPT chart specifications use lowercase snake_case while the CSV files
+  have title-cased, space separated headers. This module provides
+  convenience functions for translating between the two.
   """
 
   @mapping %{
-    "Month" => "Month",
-    "Ad Spend" => "Ad Spend",
-    "Conversions" => "Conversions",
-    "CTR" => "CTR",
-    "Impressions" => "Impressions",
-    "Cost Per Click" => "Cost Per Click",
-    "Campaign" => "Campaign"
+    "campaign" => "Campaign",
+    "cost_per_click" => "Cost Per Click",
+    "impressions" => "Impressions",
+    "clicks" => "Clicks",
+    "conversions" => "Conversions",
+    "ad_spend" => "Ad Spend",
+    "month" => "Month",
+    "ctr" => "CTR"
   }
 
   @doc """
-  Remaps a list of CSV row maps using GPT field names.
+  Returns the CSV header corresponding to the given GPT field name.
+  Unknown fields are humanised by capitalising each word.
+  """
+  @spec normalize_field(String.t()) :: String.t()
+  def normalize_field(field) when is_binary(field) do
+    Map.get(@mapping, field, humanize(field))
+  end
 
-  ## Examples
+  defp humanize(field) do
+    field
+    |> String.split("_")
+    |> Enum.map(&String.capitalize/1)
+    |> Enum.join(" ")
+  end
 
-      iex> remap_headers([%{"campaign_name" => "Jan", "spend" => 1000}])
-      [%{"Month" => "Jan", "Ad Spend" => 1000}]
+  @doc """
+  Remaps the keys of each row in the given list using `normalize_field/1`.
   """
   @spec remap_headers([map()]) :: [map()]
   def remap_headers(rows) when is_list(rows) do
-    inverse = Map.new(@mapping, fn {gpt, raw} -> {raw, gpt} end)
-
     Enum.map(rows, fn row ->
       Enum.reduce(row, %{}, fn {key, value}, acc ->
-        Map.put(acc, Map.get(inverse, key, key), value)
+        Map.put(acc, normalize_field(key), value)
       end)
     end)
   end

--- a/dashboard_gen/test/csv_header_mapper_test.exs
+++ b/dashboard_gen/test/csv_header_mapper_test.exs
@@ -1,0 +1,26 @@
+defmodule DashboardGen.CSVHeaderMapperTest do
+  use ExUnit.Case, async: true
+
+  alias DashboardGen.CSVHeaderMapper
+
+  describe "normalize_field/1" do
+    test "maps known fields" do
+      assert CSVHeaderMapper.normalize_field("cost_per_click") == "Cost Per Click"
+      assert CSVHeaderMapper.normalize_field("campaign") == "Campaign"
+    end
+
+    test "humanizes unknown fields" do
+      assert CSVHeaderMapper.normalize_field("some_field") == "Some Field"
+    end
+  end
+
+  describe "remap_headers/1" do
+    test "remaps keys of each row" do
+      rows = [%{"campaign" => "A", "cost_per_click" => 1.23}]
+
+      assert CSVHeaderMapper.remap_headers(rows) == [
+               %{"Campaign" => "A", "Cost Per Click" => 1.23}
+             ]
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- create `DashboardGen.CSVHeaderMapper` for mapping GPT field names to CSV headers
- add unit tests for mapping functions

## Testing
- `mix format`
- `mix test` *(fails: Hex could not be installed due to missing internet access)*

------
https://chatgpt.com/codex/tasks/task_e_687859074b788331aeeffcc0ff061225