### PR TITLE
Fix crash when CSV upload submitted without a file

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/uploads_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/uploads_live.ex
@@ -9,26 +9,34 @@ defmodule DashboardGenWeb.UploadsLive do
     socket =
       socket
       |> assign(:uploads_list, Uploads.list_uploads())
-      |> allow_upload(:csv, accept: ~w(.csv), max_entries: 1)
+      |> allow_upload(:csv, accept: ~w(.csv), max_entries: 1, auto_upload: true)
 
     {:ok, socket}
   end
 
   @impl true
   def handle_event("upload", %{"label" => label}, socket) do
-    {results, socket} =
-      consume_uploaded_entries(socket, :csv, fn %{path: path}, _entry ->
-        Uploads.create_upload(path, label)
-      end)
+    entries = uploaded_entries(socket, :csv)
 
     socket =
-      case results do
-        [{:ok, _}] ->
-          put_flash(socket, :info, "Upload saved")
-        [{:error, reason}] ->
-          put_flash(socket, :error, "Failed: #{inspect(reason)}")
-        [] ->
-          put_flash(socket, :error, "No file selected")
+      if entries == [] do
+        put_flash(socket, :error, "No file selected")
+      else
+        {results, socket} =
+          consume_uploaded_entries(socket, :csv, fn %{path: path}, _entry ->
+            Uploads.create_upload(path, label)
+          end)
+
+        case results do
+          [{:ok, _}] ->
+            put_flash(socket, :info, "Upload saved")
+
+          [{:error, reason}] ->
+            put_flash(socket, :error, "Failed: #{inspect(reason)}")
+
+          _ ->
+            put_flash(socket, :error, "Upload failed")
+        end
       end
       |> assign(:uploads_list, Uploads.list_uploads())
 


### PR DESCRIPTION
## Summary
- ensure upload input auto-uploads files
- guard against submitting the form with no CSV selected

## Testing
- `mix format lib/dashboard_gen_web/live/uploads_live.ex`
- `mix test` *(fails: Mix requires the Hex package manager)*

------
https://chatgpt.com/codex/tasks/task_e_6878f8a2c6c0833192dec7d46f4308ee