### PR TITLE
Fix upload handling

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/uploads_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/uploads_live.html.heex
@@ -7,7 +7,9 @@
     <.live_file_input upload={@uploads.csv} class="mt-2" />
   </div>
 
-  <button type="submit" class="px-4 py-1 bg-blue-600 text-white rounded">Upload</button>
+  <button type="submit" class="px-4 py-1 bg-blue-600 text-white rounded"
+          disabled={@uploads.csv.entries == []}
+          phx-disable-with="Uploading...">Upload</button>
 </.form>
 
 <div class="mt-6">


### PR DESCRIPTION
## Summary
- guard against missing upload entries in `UploadsLive`
- reload uploads list after upload attempt
- disable upload button when no file selected

## Testing
- `mix format lib/dashboard_gen_web/live/uploads_live.ex`
- `mix format lib/dashboard_gen_web/live/uploads_live.html.heex`
- `mix test` *(fails: Hex install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68790311603c833180e4d7de085e8cc9