### PR TITLE
Fix uploads LiveView workflow

### DIFF
--- a/dashboard_gen/assets/js/phx.js
+++ b/dashboard_gen/assets/js/phx.js
@@ -15,6 +15,18 @@ Hooks.VegaLiteChart = {
   }
 };
 
+Hooks.EnableSubmitOnFileSelect = {
+  mounted() {
+    this.el.addEventListener("change", () => {
+      const buttonId = this.el.dataset.submitButton;
+      if (buttonId) {
+        const btn = document.getElementById(buttonId);
+        if (btn) btn.disabled = this.el.files.length === 0;
+      }
+    });
+  }
+};
+
 // Initialize LiveView socket with CSRF token from meta tag
 const csrfToken = document.querySelector("meta[name='csrf-token']")?.getAttribute("content");
 const liveSocket = new LiveSocket("/live", Socket, {

--- a/dashboard_gen/lib/dashboard_gen_web/live/uploads_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/uploads_live.html.heex
@@ -1,14 +1,21 @@
 <h2 class="text-lg font-semibold mb-4">Upload CSV Dataset</h2>
 
-<.form id="upload-form" phx-submit="upload" class="space-y-2">
+<.form id="upload-form" phx-submit="upload" multipart={true} class="space-y-2">
   <input type="text" name="label" placeholder="Optional label" class="border rounded px-2 py-1" />
 
   <div phx-drop-target={@uploads.csv.ref}>
-    <.live_file_input upload={@uploads.csv} class="mt-2" />
+    <.live_file_input
+      upload={@uploads.csv}
+      class="mt-2"
+      phx-hook="EnableSubmitOnFileSelect"
+      data-submit-button="upload-submit"
+    />
   </div>
 
   <button
     type="submit"
+    id="upload-submit"
+    disabled={@uploads.csv.entries == []}
     class="px-4 py-1 bg-blue-600 text-white rounded disabled:opacity-50"
   >
     Upload


### PR DESCRIPTION
## Summary
- handle missing file uploads in `UploadsLive`
- add debug logging and refresh uploaded list
- disable upload button until a file is picked
- JS hook to enable button if LiveView reactivity fails

## Testing
- `mix format --check-formatted lib/dashboard_gen_web/live/uploads_live.ex lib/dashboard_gen_web/live/uploads_live.html.heex assets/js/phx.js`
- `mix test` *(fails: Mix requires the Hex package manager)*

------
https://chatgpt.com/codex/tasks/task_e_687906d0e4648331a4f4facbe9597f49