### PR TITLE
Improve GPT chart field resolution

### DIFF
--- a/dashboard_gen/lib/dashboard_gen/uploads.ex
+++ b/dashboard_gen/lib/dashboard_gen/uploads.ex
@@ -11,12 +11,12 @@ defmodule DashboardGen.Uploads do
 
   @doc "List all uploads ordered by inserted_at descending"
   def list_uploads do
-    Repo.all(from u in Upload, order_by: [desc: u.inserted_at])
+    Repo.all(from(u in Upload, order_by: [desc: u.inserted_at]))
   end
 
   @doc "Get the most recent upload"
   def latest_upload do
-    Repo.one(from u in Upload, order_by: [desc: u.inserted_at], limit: 1)
+    Repo.one(from(u in Upload, order_by: [desc: u.inserted_at], limit: 1))
   end
 
   @doc "Create an upload record from a CSV file path"
@@ -36,7 +36,9 @@ defmodule DashboardGen.Uploads do
       rows = CSV.parse_string(content)
 
       case rows do
-        [] -> {:error, "CSV is empty"}
+        [] ->
+          {:error, "CSV is empty"}
+
         [header_row | data_rows] ->
           normalized = Enum.map(header_row, &normalize_header/1)
           headers = Enum.zip(normalized, header_row) |> Map.new()
@@ -58,14 +60,19 @@ defmodule DashboardGen.Uploads do
 
   defp convert_value(value) when is_binary(value) do
     cond do
-      value == "" -> nil
+      value == "" ->
+        nil
+
       Integer.parse(value) != :error and match?({_, ""}, Integer.parse(value)) ->
         {int, _} = Integer.parse(value)
         int
+
       Float.parse(value) != :error and match?({_, ""}, Float.parse(value)) ->
         {float, _} = Float.parse(value)
         float
-      true -> value
+
+      true ->
+        value
     end
   end
 
@@ -77,4 +84,35 @@ defmodule DashboardGen.Uploads do
     |> String.downcase()
     |> String.replace(~r/[\s-]+/, "_")
   end
+
+  @doc """
+  Resolve a loosely matching field name to one of the dataset headers. Matching
+  is case-insensitive and works on substrings. If multiple headers match, an
+  exact match is preferred, otherwise the longest matching header is returned.
+  Returns `nil` when no match can be found.
+  """
+  @spec resolve_field(String.t() | nil, map()) :: String.t() | nil
+  def resolve_field(field, headers)
+
+  def resolve_field(nil, _headers), do: nil
+
+  def resolve_field(field, headers) when is_binary(field) and is_map(headers) do
+    normalized = normalize_header(field)
+    keys = Map.keys(headers)
+
+    cond do
+      normalized in keys ->
+        normalized
+
+      true ->
+        keys
+        |> Enum.filter(fn key ->
+          String.contains?(key, normalized) or String.contains?(normalized, key)
+        end)
+        |> Enum.sort_by(&String.length/1, :desc)
+        |> List.first()
+    end
+  end
+
+  def resolve_field(_, _), do: nil
 end


### PR DESCRIPTION
## Summary
- improve GPT prompt to only use available fields
- relax chart spec validation
- add `Uploads.resolve_field/2` for fuzzy field lookup
- map GPT chart spec fields through `resolve_field/2`
- show helpful error when fields cannot be resolved

## Testing
- `mix format lib/dashboard_gen/gpt_client.ex lib/dashboard_gen/uploads.ex lib/dashboard_gen_web/live/dashboard_live.ex`
- `mix test` *(fails: requires Hex)*

------
https://chatgpt.com/codex/tasks/task_e_687920729f7c8331a8bf5b96c80a23a4