### PR TITLE
Fix icon docs syntax

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/core_components.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/core_components.ex
@@ -6,7 +6,9 @@ defmodule DashboardGenWeb.CoreComponents do
   """
   use Phoenix.Component
 
-  @doc """Render an SVG icon from the assets/icons directory."""
+  @doc """
+  Render an SVG icon from the assets/icons directory.
+  """
   attr :name, :string, required: true
   attr :class, :string, default: nil
   attr :rest, :global, default: %{}


### PR DESCRIPTION
## Summary
- fix invalid `@doc` syntax for the icon component

## Testing
- `mix deps.get` *(fails: could not fetch hex)*
- `mix compile` *(fails: Hex not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687926b46b3483318d55cb0be370e82c