### PR TITLE
Fix textarea hook requirement

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
@@ -18,7 +18,7 @@
         </button>
         <button type="button" class="px-2 py-1 text-sm rounded bg-gray-100 hover:bg-gray-200">Tools</button>
       </div>
-      <textarea name="prompt" rows="1" phx-hook="AutoGrow"
+      <textarea name="prompt" id="prompt" rows="1" phx-hook="AutoGrow"
         placeholder="Type your request..."
         class="flex-1 resize-none border rounded-lg p-2 min-h-[40px] max-h-40 overflow-y-auto"><%= @prompt %></textarea>
       <button type="submit" class="p-2 rounded-full bg-black text-white hover:bg-gray-800 transition">


### PR DESCRIPTION
## Summary
- add missing `id` attribute for the `phx-hook` AutoGrow

## Testing
- `mix test` *(fails: Could not install Hex)*

------
https://chatgpt.com/codex/tasks/task_e_687929e5b9d08331b319d8ae10bdbe5e