### PR TITLE
Fix CSV upload BOM handling

### DIFF
--- a/dashboard_gen/lib/dashboard_gen/uploads.ex
+++ b/dashboard_gen/lib/dashboard_gen/uploads.ex
@@ -133,6 +133,7 @@ defmodule DashboardGen.Uploads do
 
   def normalize_header(header) do
     header
+    |> String.trim_leading("\uFEFF")
     |> String.trim()
     |> String.downcase()
     |> String.replace(~r/[\s-]+/, "_")

--- a/dashboard_gen/lib/dashboard_gen_web/live/uploads_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/uploads_live.ex
@@ -35,7 +35,7 @@ defmodule DashboardGenWeb.UploadsLive do
     Logger.info("Finished uploading #{entry.client_name}")
     label = socket.assigns[:label] || "Untitled Upload"
 
-    {results, socket} =
+    results =
       consume_uploaded_entries(socket, :csv, fn %{path: path}, _entry ->
         Uploads.create_upload(path, label)
       end)

--- a/dashboard_gen/test/uploads_test.exs
+++ b/dashboard_gen/test/uploads_test.exs
@@ -35,6 +35,19 @@ defmodule DashboardGen.UploadsTest do
            }
   end
 
+  test "parse_csv handles BOM in headers" do
+    bom = <<239, 187, 191>>
+    csv = [
+      bom <> "date,campaign_id,campaign_name,cost_per_click,impressions,clicks,conversions,source",
+      "2023-01-01,1,Campaign,0.5,100,10,1,google"
+    ] |> Enum.join("\n")
+    path = Path.join(System.tmp_dir!(), "upload_bom.csv")
+    File.write!(path, csv)
+
+    assert {:ok, %{headers: headers, rows: [_]}} = Uploads.parse_csv(path)
+    assert Map.has_key?(headers, "date")
+  end
+
   test "parse_csv errors when required header missing" do
     csv = [
       "date,campaign name,cpc,impressions,conversions,google_ads",


### PR DESCRIPTION
## Summary
- fix `handle_progress` to match consume_uploaded_entries return value
- strip UTF-8 BOM from uploaded CSV headers
- add regression test for BOM headers

## Testing
- `mix test` *(fails: could not fetch hex)*

------
https://chatgpt.com/codex/tasks/task_e_6879356a841c83319f0e5473aa627874