### PR TITLE
Improve CSV parsing robustness

### DIFF
--- a/dashboard_gen/lib/dashboard_gen/uploads.ex
+++ b/dashboard_gen/lib/dashboard_gen/uploads.ex
@@ -8,6 +8,7 @@ defmodule DashboardGen.Uploads do
 
   alias DashboardGen.Uploads.Upload
   alias NimbleCSV.RFC4180, as: CSV
+  require Logger
 
   @canonical_headers [
     "date",
@@ -44,47 +45,63 @@ defmodule DashboardGen.Uploads do
   @doc "Parse a CSV file returning headers map and rows"
   def parse_csv(path) do
     with {:ok, content} <- File.read(path) do
-      rows = CSV.parse_string(content)
+      content =
+        case content do
+          <<239, 187, 191, rest::binary>> -> rest
+          _ -> content
+        end
+
+      rows =
+        content
+        |> CSV.parse_string()
+        |> Enum.drop_while(&blank_row?/1)
 
       case rows do
         [] ->
           {:error, "CSV is empty"}
 
         [header_row | data_rows] ->
-          canonical = Enum.map(header_row, &canonical_header/1)
+          Logger.debug("raw first row: #{inspect(header_row)}")
 
-          headers =
-            Enum.zip(canonical, header_row)
-            |> Enum.reduce(%{}, fn {canon, raw}, acc ->
-              if canon in @canonical_headers, do: Map.put_new(acc, canon, raw), else: acc
-            end)
+          if header_looks_like_data?(header_row) do
+            {:error, "CSV is missing header row — it starts with data"}
+          else
+            canonical = Enum.map(header_row, &canonical_header/1)
+            Logger.debug("inferred headers: #{inspect(canonical)}")
 
-          missing =
-            Enum.filter(@canonical_headers, fn key ->
-              not Map.has_key?(headers, key)
-            end)
+            headers =
+              Enum.zip(canonical, header_row)
+              |> Enum.reduce(%{}, fn {canon, raw}, acc ->
+                if canon in @canonical_headers, do: Map.put_new(acc, canon, raw), else: acc
+              end)
 
-          cond do
-            missing != [] ->
-              {:error, "Invalid CSV: missing required column '#{List.first(missing)}'"}
+            missing =
+              Enum.filter(@canonical_headers, fn key ->
+                not Map.has_key?(headers, key)
+              end)
 
-            Enum.all?(data_rows, &(length(&1) == length(header_row))) ->
-              maps =
-                Enum.map(data_rows, fn row ->
-                  Enum.zip(canonical, row)
-                  |> Enum.reduce(%{}, fn {k, v}, acc ->
-                    if k in @canonical_headers do
-                      Map.put(acc, k, convert_value(v))
-                    else
-                      acc
-                    end
+            cond do
+              missing != [] ->
+                {:error, "Invalid CSV: missing required column '#{List.first(missing)}'"}
+
+              Enum.all?(data_rows, &(length(&1) == length(header_row))) ->
+                maps =
+                  Enum.map(data_rows, fn row ->
+                    Enum.zip(canonical, row)
+                    |> Enum.reduce(%{}, fn {k, v}, acc ->
+                      if k in @canonical_headers do
+                        Map.put(acc, k, convert_value(v))
+                      else
+                        acc
+                      end
+                    end)
                   end)
-                end)
 
-              {:ok, %{headers: headers, rows: maps}}
+                {:ok, %{headers: headers, rows: maps}}
 
-            true ->
-              {:error, "CSV rows have inconsistent number of fields"}
+              true ->
+                {:error, "CSV rows have inconsistent number of fields"}
+            end
           end
       end
     end
@@ -109,6 +126,16 @@ defmodule DashboardGen.Uploads do
   end
 
   defp convert_value(value), do: value
+
+  defp blank_row?(row) do
+    Enum.all?(row, fn cell -> String.trim(cell) == "" end)
+  end
+
+  defp header_looks_like_data?([first | _]) do
+    Regex.match?(~r/^\d{4}-\d{2}-\d{2}$/, String.trim_leading(first, "\uFEFF") |> String.trim())
+  end
+
+  defp header_looks_like_data?(_), do: false
 
   defp canonical_header(header) do
     normalized = normalize_header(header)

--- a/dashboard_gen/test/uploads_test.exs
+++ b/dashboard_gen/test/uploads_test.exs
@@ -48,6 +48,19 @@ defmodule DashboardGen.UploadsTest do
     assert Map.has_key?(headers, "date")
   end
 
+  test "parse_csv errors when headers are missing and first row is data" do
+    csv = [
+      "2023-01-01,1,Campaign,0.5,100,10,1,google",
+      "2023-01-02,2,Another,0.4,200,20,3,bing"
+    ] |> Enum.join("\n")
+
+    path = Path.join(System.tmp_dir!(), "upload_no_header.csv")
+    File.write!(path, csv)
+
+    assert {:error, msg} = Uploads.parse_csv(path)
+    assert msg =~ "missing header row"
+  end
+
   test "parse_csv errors when required header missing" do
     csv = [
       "date,campaign name,cpc,impressions,conversions,google_ads",


### PR DESCRIPTION
## Summary
- strip BOM before parsing CSVs and drop leading blank rows
- validate header row and add helpful debug logging
- detect malformed CSVs that start with data
- add unit test for data-as-header scenario

## Testing
- `mix test` *(fails: Could not install Hex)*

------
https://chatgpt.com/codex/tasks/task_e_6879412907bc8331a85d4b9ff72acfb2