### PR TITLE
Add GPT summarizer to dashboard

### DIFF
--- a/dashboard_gen/lib/dashboard_gen/codex/summarizer.ex
+++ b/dashboard_gen/lib/dashboard_gen/codex/summarizer.ex
@@ -1,0 +1,28 @@
+defmodule DashboardGen.Codex.Summarizer do
+  @moduledoc """
+  Generate short textual insights for chart data using GPT.
+  """
+
+  alias DashboardGen.CodexClient
+
+  @spec summarize(String.t(), list(), list()) :: {:ok, String.t()} | {:error, any()}
+  def summarize(query_text, headers, rows)
+      when is_binary(query_text) and is_list(headers) and is_list(rows) do
+    prompt = """
+    You're a marketing analyst. Given the following query and data, return a short summary (2–3 sentences) with insights.
+
+    Query: #{query_text}
+
+    Headers: #{inspect(headers)}
+
+    First few rows:
+    #{Jason.encode!(Enum.take(rows, 5))}
+
+    Focus on trends, spikes, or performance anomalies.
+    """
+
+    CodexClient.ask(prompt)
+  end
+
+  def summarize(_, _, _), do: {:error, :invalid_arguments}
+end

--- a/dashboard_gen/lib/dashboard_gen/codex_client.ex
+++ b/dashboard_gen/lib/dashboard_gen/codex_client.ex
@@ -1,0 +1,24 @@
+defmodule DashboardGen.CodexClient do
+  @moduledoc false
+
+  @openai_url "https://api.openai.com/v1/chat/completions"
+
+  @spec ask(String.t()) :: {:ok, String.t()} | {:error, any()}
+  def ask(prompt) when is_binary(prompt) do
+    with api_key when is_binary(api_key) <-
+           System.get_env("OPENAI_API_KEY") ||
+             {:error, "OPENAI_API_KEY environment variable is missing"},
+         body <- %{model: "gpt-3.5-turbo", messages: [%{role: "user", content: prompt}]},
+         headers <- [{"authorization", "Bearer #{api_key}"}, {"content-type", "application/json"}],
+         {:ok, %Req.Response{status: 200, body: %{"choices" => choices}}} <-
+           Req.post(@openai_url, json: body, headers: headers),
+         %{"message" => %{"content" => content}} <- List.first(choices) do
+      {:ok, String.trim(content)}
+    else
+      {:error, %Req.Response{body: body}} -> {:error, inspect(body)}
+      {:error, reason} -> {:error, inspect(reason)}
+      nil -> {:error, "OPENAI_API_KEY environment variable is missing"}
+      _ -> {:error, "Invalid response from OpenAI"}
+    end
+  end
+end

--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
@@ -8,6 +8,12 @@
 
     <div :if={@chart_spec} id="chart-container" class="mt-6" phx-hook="VegaLiteChart" phx-update="ignore" data-spec={@chart_spec}>
     </div>
+    <div :if={@summary} class="mt-4 bg-gray-50 p-4 rounded text-sm text-gray-700">
+      <strong>Insight:</strong> <%= @summary %>
+    </div>
+    <%= if @chart_spec && !@summary && !@loading do %>
+      <button phx-click="generate_summary" class="btn mt-4">Generate Insight</button>
+    <% end %>
   </div>
 
   <%= if @collapsed do %>


### PR DESCRIPTION
## Summary
- implement `DashboardGen.Codex.Summarizer` using `CodexClient`
- create `CodexClient` wrapper for OpenAI requests
- extend dashboard LiveView to trigger and display summaries
- update dashboard template with summary box and button

## Testing
- `mix format`
- `mix test` *(fails: Mix requires Hex; cannot install without internet)*

------
https://chatgpt.com/codex/tasks/task_e_68799fdbba688331b9942bdf7ae832b6