### PR TITLE
Fix sidebar toggle session

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
@@ -41,7 +41,7 @@ defmodule DashboardGenWeb.DashboardLive do
     {:noreply,
      socket
      |> assign(:collapsed?, collapsed?)
-     |> put_session("sidebar_collapsed", collapsed?)}
+     |> Phoenix.LiveView.put_session("sidebar_collapsed", collapsed?)}
   end
 
   def handle_event("generate_summary", _params, socket) do


### PR DESCRIPTION
## Summary
- store sidebar state using `Phoenix.LiveView.put_session`

## Testing
- `mix compile` *(fails: requires Hex install)*

------
https://chatgpt.com/codex/tasks/task_e_6879bc8144c88331a2223ae7dbcdaa18