### PR TITLE
Revert recent changes

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
@@ -41,7 +41,7 @@ defmodule DashboardGenWeb.DashboardLive do
     {:noreply,
      socket
      |> assign(:collapsed?, collapsed?)
-     |> Phoenix.LiveView.put_session("sidebar_collapsed", collapsed?)}
+     |> put_session("sidebar_collapsed", collapsed?)}
   end
 
   def handle_event("generate_summary", _params, socket) do


### PR DESCRIPTION
## Summary
- revert fix commit for sidebar toggle session
- add empty revert commit for `Fix put_session call in DashboardLive`

## Testing
- `mix test` *(fails: Hex not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6879bdde1b508331b13e432707faf117