### PR TITLE
Refactor DashboardLive layout

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
@@ -1,5 +1,5 @@
 defmodule DashboardGenWeb.DashboardLive do
-  use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :dashboard}
+  use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :root}
   use DashboardGenWeb, :html
   import DashboardGenWeb.CoreComponents
   alias DashboardGen.GPTClient
@@ -28,13 +28,12 @@ defmodule DashboardGenWeb.DashboardLive do
        prompt: prompt,
        loading: true,
        chart_spec: nil,
-       collapsed: true,
        summary: nil
      )}
   end
 
-  def handle_event("expand_input", _params, socket) do
-    {:noreply, assign(socket, collapsed: false)}
+  def handle_event("toggle_sidebar", _params, socket) do
+    {:noreply, update(socket, :collapsed, &(!&1))}
   end
 
   def handle_event("generate_summary", _params, socket) do
@@ -166,4 +165,7 @@ defmodule DashboardGenWeb.DashboardLive do
     |> VegaLite.encode(:y, field: "value", type: :quantitative)
     |> VegaLite.encode(:color, field: "category", type: :nominal)
   end
+
+  def sidebar_classes(true), do: "w-16 bg-gray-800 text-white transition-all"
+  def sidebar_classes(false), do: "w-64 bg-gray-800 text-white transition-all"
 end

--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
@@ -1,42 +1,47 @@
-<div class="flex flex-col h-full">
-  <div class="flex-1 overflow-y-auto">
+<div class="flex h-screen">
+  <aside class={sidebar_classes(@collapsed)}>
+    <div class="flex items-center justify-between p-4 border-b">
+      <span class="text-lg font-semibold">DashboardGen</span>
+      <button phx-click="toggle_sidebar" aria-label="Toggle sidebar">☰</button>
+    </div>
+
+    <nav class="p-4 space-y-2">
+      <Phoenix.Component.link navigate={~p"/"} class="block text-sm hover:underline">Dashboard</Phoenix.Component.link>
+      <Phoenix.Component.link navigate={~p"/saved"} class="block text-sm hover:underline">Saved Views</Phoenix.Component.link>
+      <Phoenix.Component.link navigate={~p"/settings"} class="block text-sm hover:underline">Settings</Phoenix.Component.link>
+      <Phoenix.Component.link navigate={~p"/uploads"} class="block text-sm hover:underline">Uploads</Phoenix.Component.link>
+    </nav>
+  </aside>
+
+  <main class="flex-1 overflow-y-auto p-6 flex flex-col space-y-6">
     <%= if live_flash(@flash, :error) do %>
-      <div class="text-red-600 mb-2"><%= live_flash(@flash, :error) %></div>
+      <div class="text-red-600"><%= live_flash(@flash, :error) %></div>
     <% end %>
 
-    <div :if={@loading} class="mt-2 text-gray-500">Generating...</div>
-
-    <div :if={@chart_spec} id="chart-container" class="mt-6" phx-hook="VegaLiteChart" phx-update="ignore" data-spec={@chart_spec}>
-    </div>
-    <div :if={@summary} class="mt-4 bg-gray-50 p-4 rounded text-sm text-gray-700">
-      <strong>Insight:</strong> <%= @summary %>
-    </div>
-    <%= if @chart_spec && !@summary && !@loading do %>
-      <button phx-click="generate_summary" class="btn mt-4">Generate Insight</button>
+    <%= if @loading do %>
+      <div class="text-gray-500">Generating...</div>
     <% end %>
-  </div>
 
-  <%= if @collapsed do %>
-    <div class="border-t bg-white p-4 fixed bottom-0 inset-x-0">
-      <div class="max-w-4xl mx-auto flex items-center justify-between rounded-xl border border-gray-300 bg-white shadow-sm px-4 py-2">
-        <div class="flex-1 text-sm text-gray-700 truncate" aria-label="Collapsed prompt"><%= @prompt %></div>
-        <button type="button" phx-click="expand_input" aria-label="Expand input" class="ml-2 rounded-full bg-black text-white text-xs px-3 py-1">+</button>
+    <%= if @chart_spec do %>
+      <div id="chart-container" phx-hook="VegaLiteChart" phx-update="ignore" data-spec={@chart_spec} />
+    <% end %>
+
+    <%= if @summary do %>
+      <div class="bg-gray-50 p-4 rounded text-sm text-gray-700">
+        <strong>Insight:</strong> <%= @summary %>
       </div>
-    </div>
-  <% else %>
-    <form phx-submit="generate" class="border-t bg-white p-4 fixed bottom-0 inset-x-0">
-      <div class="max-w-4xl mx-auto rounded-xl border border-gray-300 shadow-sm bg-white px-4 py-2 transition-all">
-        <div class="flex items-center justify-between">
-          <textarea name="prompt" id="prompt" rows="1" phx-hook="AutoGrow" placeholder="Describe a task" aria-label="Task description" class="flex-1 resize-none bg-transparent focus:outline-none placeholder-gray-400 overflow-hidden"></textarea>
-          <button type="submit" aria-label="Submit task" class="ml-2 rounded-full bg-black text-white text-sm px-3 py-1">Go</button>
-        </div>
-        <div class="flex space-x-2 border-t border-gray-200 pt-1 mt-2 text-xs text-gray-500">
-          <button type="button" class="px-2 py-1 hover:text-black">[📁] stephenszpak/nl-dash...</button>
-          <button type="button" class="px-2 py-1 hover:text-black">[🔀] main</button>
-          <button type="button" class="px-2 py-1 hover:text-black">[📦] 1x</button>
-        </div>
+    <% end %>
+
+    <%= if @chart_spec && !@summary && !@loading do %>
+      <button phx-click="generate_summary" class="btn">Generate Insight</button>
+    <% end %>
+
+    <form phx-submit="generate" class="bg-white border rounded-xl shadow-sm p-4">
+      <textarea name="prompt" rows="2" placeholder="Describe your query..." class="w-full resize-none bg-transparent text-sm placeholder-gray-400"></textarea>
+      <div class="flex justify-end mt-2">
+        <button type="submit" class="px-4 py-2 bg-black text-white text-sm rounded">Generate</button>
       </div>
     </form>
-  <% end %>
+  </main>
 </div>
 


### PR DESCRIPTION
## Summary
- embed sidebar and prompt input directly in DashboardLive
- allow toggling sidebar state via `@collapsed`
- keep prompt form inside main scroll area

## Testing
- `mix format`
- `mix test` *(fails: Mix requires Hex packages)*

------
https://chatgpt.com/codex/tasks/task_e_687a4663dea8833190ad20fef5b32225