### PR TITLE
Improve Dashboard UI

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
@@ -1,22 +1,33 @@
 <div class="flex h-screen">
   <aside class={sidebar_classes(@collapsed)}>
-    <div class="flex items-center justify-between p-4 border-b">
-      <span class="text-lg font-semibold">DashboardGen</span>
-      <button phx-click="toggle_sidebar" aria-label="Toggle sidebar">☰</button>
+    <div class="flex justify-between items-center p-3 border-b">
+      <span :if={!@collapsed} class="text-lg font-semibold">DashboardGen</span>
+      <button phx-click="toggle_sidebar" aria-label="Toggle sidebar">
+        <%= if @collapsed, do: "▶", else: "◀" %>
+      </button>
     </div>
 
-    <nav class="p-4 space-y-2">
-      <Phoenix.Component.link navigate={~p"/"} class="block text-sm hover:underline">Dashboard</Phoenix.Component.link>
-      <Phoenix.Component.link navigate={~p"/saved"} class="block text-sm hover:underline">Saved Views</Phoenix.Component.link>
-      <Phoenix.Component.link navigate={~p"/settings"} class="block text-sm hover:underline">Settings</Phoenix.Component.link>
-      <Phoenix.Component.link navigate={~p"/uploads"} class="block text-sm hover:underline">Uploads</Phoenix.Component.link>
+    <nav class="space-y-2 p-3">
+      <Phoenix.Component.link navigate={~p"/"} class="nav-item flex items-center gap-2 text-sm hover:underline">
+        📊 <%= unless @collapsed, do: "Dashboard" %>
+      </Phoenix.Component.link>
+      <Phoenix.Component.link navigate={~p"/saved"} class="nav-item flex items-center gap-2 text-sm hover:underline">
+        💾 <%= unless @collapsed, do: "Saved Views" %>
+      </Phoenix.Component.link>
+      <Phoenix.Component.link navigate={~p"/settings"} class="nav-item flex items-center gap-2 text-sm hover:underline">
+        ⚙️ <%= unless @collapsed, do: "Settings" %>
+      </Phoenix.Component.link>
+      <Phoenix.Component.link navigate={~p"/uploads"} class="nav-item flex items-center gap-2 text-sm hover:underline">
+        📁 <%= unless @collapsed, do: "Uploads" %>
+      </Phoenix.Component.link>
     </nav>
   </aside>
 
-  <main class="flex-1 overflow-y-auto p-6 flex flex-col space-y-6">
-    <%= if live_flash(@flash, :error) do %>
-      <div class="text-red-600"><%= live_flash(@flash, :error) %></div>
-    <% end %>
+  <main class="flex-1 flex flex-col justify-between overflow-y-auto">
+    <div class="p-6 space-y-6 overflow-y-auto">
+      <%= if live_flash(@flash, :error) do %>
+        <div class="text-red-600"><%= live_flash(@flash, :error) %></div>
+      <% end %>
 
     <%= if @loading do %>
       <div class="text-gray-500">Generating...</div>
@@ -32,14 +43,20 @@
       </div>
     <% end %>
 
-    <%= if @chart_spec && !@summary && !@loading do %>
-      <button phx-click="generate_summary" class="btn">Generate Insight</button>
-    <% end %>
+      <%= if @chart_spec && !@summary && !@loading do %>
+        <button phx-click="generate_summary" class="btn">Generate Insight</button>
+      <% end %>
+    </div>
 
-    <form phx-submit="generate" class="bg-white border rounded-xl shadow-sm p-4">
-      <textarea name="prompt" rows="2" placeholder="Describe your query..." class="w-full resize-none bg-transparent text-sm placeholder-gray-400"></textarea>
-      <div class="flex justify-end mt-2">
-        <button type="submit" class="px-4 py-2 bg-black text-white text-sm rounded">Generate</button>
+    <form phx-submit="generate" class="p-6 bg-white border-t">
+      <div class="flex items-end gap-2 border border-gray-300 rounded-xl shadow-sm p-3 bg-white">
+        <textarea
+          name="prompt"
+          rows="1"
+          placeholder="Describe your query..."
+          class="flex-1 resize-none rounded-md border-none outline-none focus:ring-0 text-sm"
+        ></textarea>
+        <button type="submit" class="bg-black text-white rounded-full px-3 py-1 text-sm">➤</button>
       </div>
     </form>
   </main>


### PR DESCRIPTION
## Summary
- update sidebar collapse UX with chevron button
- show emoji icons in sidebar links
- anchor prompt form to bottom of main area
- restyle prompt form like ChatGPT

## Testing
- `mix format`
- `mix test` *(fails: could not install Hex)*

------
https://chatgpt.com/codex/tasks/task_e_687a4af9e4b08331b96752f459d9ef34