### PR TITLE
Add explanation and why features

### DIFF
--- a/dashboard_gen/lib/dashboard_gen/codex/explainer.ex
+++ b/dashboard_gen/lib/dashboard_gen/codex/explainer.ex
@@ -6,19 +6,19 @@ defmodule DashboardGen.Codex.Explainer do
   alias DashboardGen.CodexClient
 
   @doc """
-  Explain the provided query and data with a short summary.
+  Explain the provided query results.
   """
   @spec explain(String.t(), list(), list()) :: {:ok, String.t()} | {:error, any()}
   def explain(query_text, headers, rows)
       when is_binary(query_text) and is_list(headers) and is_list(rows) do
     prompt = """
-    You're a senior marketing analyst. Explain the following query and data in 2–4 sentences.
+    You're a senior marketing analyst. What does this data show?
 
     Query: #{query_text}
     Headers: #{inspect(headers)}
-    First few rows: #{Jason.encode!(Enum.take(rows, 5))}
+    Data: #{Jason.encode!(Enum.take(rows, 5))}
 
-    Explain what the data shows — trends, notable values, and high-level takeaways.
+    Provide 2–3 sentences summarizing the result.
     """
 
     CodexClient.ask(prompt)
@@ -27,19 +27,19 @@ defmodule DashboardGen.Codex.Explainer do
   def explain(_, _, _), do: {:error, :invalid_arguments}
 
   @doc """
-  Suggest reasons why the results might have occurred based on the data.
+  Suggest reasons why the results might have occurred.
   """
   @spec why(String.t(), list(), list()) :: {:ok, String.t()} | {:error, any()}
   def why(query_text, headers, rows)
       when is_binary(query_text) and is_list(headers) and is_list(rows) do
     prompt = """
-    You're a marketing performance analyst. Based on this data, why might these results have occurred?
+    You're a marketing performance analyst. Based on this data and query, why might these results have occurred?
 
     Query: #{query_text}
     Headers: #{inspect(headers)}
-    First few rows: #{Jason.encode!(Enum.take(rows, 5))}
+    Data: #{Jason.encode!(Enum.take(rows, 5))}
 
-    Suggest plausible causes related to campaign timing, channels, or audience behavior. Be concise (2–3 sentences).
+    Give possible causes like timing, platform behavior, or user engagement shifts. Be concise.
     """
 
     CodexClient.ask(prompt)

--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
@@ -35,6 +35,13 @@
 
     <%= if @chart_spec do %>
       <div id="chart-container" phx-hook="VegaLiteChart" phx-update="ignore" data-spec={@chart_spec} />
+      <div class="mt-4 space-x-2">
+        <%= if !@summary && !@loading do %>
+          <button phx-click="generate_summary" class="btn">Generate Insight</button>
+        <% end %>
+        <button phx-click="explain_this" class="btn-secondary">Explain This</button>
+        <button phx-click="why_this" class="btn-secondary">Why Did This Happen?</button>
+      </div>
     <% end %>
 
     <%= if @summary do %>
@@ -42,10 +49,11 @@
         <strong>Insight:</strong> <%= @summary %>
       </div>
     <% end %>
-
-      <%= if @chart_spec && !@summary && !@loading do %>
-        <button phx-click="generate_summary" class="btn">Generate Insight</button>
-      <% end %>
+    <%= if @explanation do %>
+      <div class="bg-yellow-50 p-4 rounded mt-4 text-sm text-yellow-900">
+        <strong>Explanation:</strong> <%= @explanation %>
+      </div>
+    <% end %>
     </div>
 
     <form phx-submit="generate" class="p-6 bg-white border-t">


### PR DESCRIPTION
## Summary
- update `Codex.Explainer` prompts for explanation and why analysis
- support explain/why actions in `DashboardLive`
- add buttons and explanation display in the dashboard UI

## Testing
- `mix format` *(fails: `mix: command not found`)*
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687a4f7a4b1483318b0bd5e091927197