### PR TITLE
Add anomaly alerts on dashboard

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
@@ -33,6 +33,12 @@
       <div class="text-gray-500">Generating...</div>
     <% end %>
 
+    <%= if @alerts do %>
+      <div class="bg-yellow-50 border-l-4 border-yellow-400 text-yellow-900 p-4 rounded text-sm">
+        <strong>⚠️ Alert:</strong> <%= @alerts %>
+      </div>
+    <% end %>
+
     <%= if @chart_spec do %>
       <div id="chart-container" phx-hook="VegaLiteChart" phx-update="ignore" data-spec={@chart_spec} />
       <div class="mt-4 space-x-2">


### PR DESCRIPTION
## Summary
- integrate `AnomalyDetector` with DashboardLive
- surface alert summaries after charts are generated

## Testing
- `mix test` *(fails: Could not install Hex)*

------
https://chatgpt.com/codex/tasks/task_e_687a5619f0a48331ada6682de6ca21f9