### PR TITLE
Implement simple login & onboarding

### DIFF
--- a/dashboard_gen/lib/dashboard_gen/accounts.ex
+++ b/dashboard_gen/lib/dashboard_gen/accounts.ex
@@ -1,0 +1,33 @@
+defmodule DashboardGen.Accounts do
+  @moduledoc false
+  import Ecto.Query, warn: false
+  alias DashboardGen.Repo
+  alias DashboardGen.Accounts.User
+
+  def get_user(id), do: Repo.get(User, id)
+
+  def get_user_by_email(email) when is_binary(email) do
+    Repo.get_by(User, email: email)
+  end
+
+  def create_user(attrs) do
+    %User{}
+    |> User.registration_changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def authenticate_user(email, password) when is_binary(email) and is_binary(password) do
+    with %User{} = user <- get_user_by_email(email),
+         true <- Bcrypt.verify_pass(password, user.hashed_password) do
+      {:ok, user}
+    else
+      _ -> :error
+    end
+  end
+
+  def mark_onboarded(%User{} = user) do
+    user
+    |> Ecto.Changeset.change(onboarded_at: DateTime.utc_now())
+    |> Repo.update()
+  end
+end

--- a/dashboard_gen/lib/dashboard_gen/accounts/user.ex
+++ b/dashboard_gen/lib/dashboard_gen/accounts/user.ex
@@ -1,0 +1,31 @@
+defmodule DashboardGen.Accounts.User do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "users" do
+    field(:email, :string)
+    field(:hashed_password, :string)
+    field(:onboarded_at, :utc_datetime)
+
+    timestamps()
+  end
+
+  @doc false
+  def registration_changeset(user, attrs) do
+    user
+    |> cast(attrs, [:email, :password, :password_confirmation])
+    |> validate_required([:email, :password, :password_confirmation])
+    |> validate_format(:email, ~r/@/)
+    |> validate_confirmation(:password)
+    |> unique_constraint(:email)
+    |> put_password_hash()
+  end
+
+  defp put_password_hash(changeset) do
+    if password = get_change(changeset, :password) do
+      change(changeset, hashed_password: Bcrypt.hash_pwd_salt(password))
+    else
+      changeset
+    end
+  end
+end

--- a/dashboard_gen/lib/dashboard_gen_web/controllers/auth_controller.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/controllers/auth_controller.ex
@@ -1,0 +1,9 @@
+defmodule DashboardGenWeb.AuthController do
+  use DashboardGenWeb, :controller
+
+  def delete(conn, _params) do
+    conn
+    |> configure_session(drop: true)
+    |> redirect(to: "/login")
+  end
+end

--- a/dashboard_gen/lib/dashboard_gen_web/live/login_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/login_live.ex
@@ -1,0 +1,23 @@
+defmodule DashboardGenWeb.LoginLive do
+  use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :root}
+  alias DashboardGen.Accounts
+
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, error: nil)}
+  end
+
+  def handle_event("login", %{"user" => %{"email" => email, "password" => password}}, socket) do
+    case Accounts.authenticate_user(email, password) do
+      {:ok, user} ->
+        dest = if is_nil(user.onboarded_at), do: "/onboarding", else: "/dashboard"
+
+        {:noreply,
+         socket
+         |> Phoenix.LiveView.put_session(:user_id, user.id)
+         |> Phoenix.LiveView.push_navigate(to: dest)}
+
+      :error ->
+        {:noreply, assign(socket, error: "Invalid email or password")}
+    end
+  end
+end

--- a/dashboard_gen/lib/dashboard_gen_web/live/login_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/login_live.html.heex
@@ -1,0 +1,17 @@
+<div class="max-w-md mx-auto mt-10">
+  <h2 class="text-xl font-semibold mb-4">Log In</h2>
+  <%= if @error do %>
+    <div class="text-red-600 mb-2"><%= @error %></div>
+  <% end %>
+  <form phx-submit="login">
+    <div class="mb-2">
+      <label class="block">Email</label>
+      <input type="email" name="user[email]" class="border px-2" />
+    </div>
+    <div class="mb-4">
+      <label class="block">Password</label>
+      <input type="password" name="user[password]" class="border px-2" />
+    </div>
+    <button class="bg-blue-500 text-white px-4 py-2">Log In</button>
+  </form>
+</div>

--- a/dashboard_gen/lib/dashboard_gen_web/live/onboarding_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/onboarding_live.ex
@@ -1,0 +1,19 @@
+defmodule DashboardGenWeb.OnboardingLive do
+  use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :root}
+  alias DashboardGen.Accounts
+
+  def mount(_params, session, socket) do
+    user = session["user_id"] && Accounts.get_user(session["user_id"])
+
+    if user do
+      {:ok, assign(socket, user: user)}
+    else
+      {:ok, Phoenix.LiveView.redirect(socket, to: "/login")}
+    end
+  end
+
+  def handle_event("run_query", _params, socket) do
+    Accounts.mark_onboarded(socket.assigns.user)
+    {:noreply, Phoenix.LiveView.push_navigate(socket, to: "/dashboard")}
+  end
+end

--- a/dashboard_gen/lib/dashboard_gen_web/live/onboarding_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/onboarding_live.html.heex
@@ -1,0 +1,8 @@
+<div class="max-w-md mx-auto mt-10 space-y-4">
+  <h2 class="text-xl font-semibold">Welcome to DashboardGen!</h2>
+  <p>Try running your first query:</p>
+  <form phx-submit="run_query">
+    <input type="text" name="query" class="border px-2 mr-2" />
+    <button class="bg-blue-500 text-white px-4 py-1">Run</button>
+  </form>
+</div>

--- a/dashboard_gen/lib/dashboard_gen_web/live/register_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/register_live.ex
@@ -1,0 +1,23 @@
+defmodule DashboardGenWeb.RegisterLive do
+  use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :root}
+  alias DashboardGen.Accounts
+  alias DashboardGen.Accounts.User
+
+  def mount(_params, _session, socket) do
+    changeset = User.registration_changeset(%User{}, %{})
+    {:ok, assign(socket, changeset: changeset)}
+  end
+
+  def handle_event("save", %{"user" => user_params}, socket) do
+    case Accounts.create_user(user_params) do
+      {:ok, user} ->
+        {:noreply,
+         socket
+         |> Phoenix.LiveView.put_session(:user_id, user.id)
+         |> Phoenix.LiveView.push_navigate(to: "/onboarding")}
+
+      {:error, changeset} ->
+        {:noreply, assign(socket, changeset: changeset)}
+    end
+  end
+end

--- a/dashboard_gen/lib/dashboard_gen_web/live/register_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/register_live.html.heex
@@ -1,0 +1,21 @@
+<div class="max-w-md mx-auto mt-10">
+  <h2 class="text-xl font-semibold mb-4">Register</h2>
+  <.form let={f} for={@changeset} phx-submit="save">
+    <div class="mb-2">
+      <%= label f, :email, class: "block" %>
+      <%= email_input f, :email, class: "border px-2" %>
+      <%= error_tag f, :email %>
+    </div>
+    <div class="mb-2">
+      <%= label f, :password, class: "block" %>
+      <%= password_input f, :password, class: "border px-2" %>
+      <%= error_tag f, :password %>
+    </div>
+    <div class="mb-4">
+      <%= label f, :password_confirmation, class: "block" %>
+      <%= password_input f, :password_confirmation, class: "border px-2" %>
+      <%= error_tag f, :password_confirmation %>
+    </div>
+    <%= submit "Register", class: "bg-blue-500 text-white px-4 py-2" %>
+  </.form>
+</div>

--- a/dashboard_gen/lib/dashboard_gen_web/plugs/auth.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/plugs/auth.ex
@@ -1,0 +1,18 @@
+defmodule DashboardGenWeb.Plugs.Auth do
+  import Plug.Conn
+  import Phoenix.Controller
+  alias DashboardGen.Accounts
+
+  def fetch_current_user(conn, _opts) do
+    user = get_session(conn, :user_id) && Accounts.get_user(get_session(conn, :user_id))
+    assign(conn, :current_user, user)
+  end
+
+  def require_authenticated(%{assigns: %{current_user: nil}} = conn, _opts) do
+    conn
+    |> redirect(to: "/login")
+    |> halt()
+  end
+
+  def require_authenticated(conn, _opts), do: conn
+end

--- a/dashboard_gen/lib/dashboard_gen_web/router.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/router.ex
@@ -7,16 +7,35 @@ defmodule DashboardGenWeb.Router do
     plug(:accepts, ["html"])
     plug(:fetch_session)
     plug(:fetch_live_flash)
+    plug(DashboardGenWeb.Plugs.Auth, :fetch_current_user)
     plug(:put_root_layout, {DashboardGenWeb.Layouts, :root})
     plug(:protect_from_forgery)
     plug(:put_secure_browser_headers)
+  end
+
+  pipeline :require_auth do
+    plug(DashboardGenWeb.Plugs.Auth, :require_authenticated)
   end
 
   scope "/", DashboardGenWeb do
     pipe_through(:browser)
 
     live("/", DashboardLive)
+    live("/register", RegisterLive)
+    live("/login", LoginLive)
+    delete("/logout", AuthController, :delete)
+  end
+
+  scope "/", DashboardGenWeb do
+    pipe_through([:browser, :require_auth])
+
     live("/dashboard", DashboardLive)
+    live("/onboarding", OnboardingLive)
+  end
+
+  scope "/", DashboardGenWeb do
+    pipe_through(:browser)
+
     live("/saved", SavedLive)
     live("/settings", SettingsLive)
     live("/uploads", UploadsLive)

--- a/dashboard_gen/mix.exs
+++ b/dashboard_gen/mix.exs
@@ -45,7 +45,8 @@ defmodule DashboardGen.MixProject do
       {:vega_lite, "~> 0.1.8"},
       {:openai, "~> 0.5"},
       {:dotenvy, "~> 0.8"},
-      {:req, "~> 0.4"}
+      {:req, "~> 0.4"},
+      {:bcrypt_elixir, "~> 3.0"}
     ]
   end
 

--- a/dashboard_gen/priv/repo/migrations/20250719000000_create_users.exs
+++ b/dashboard_gen/priv/repo/migrations/20250719000000_create_users.exs
@@ -1,0 +1,15 @@
+defmodule DashboardGen.Repo.Migrations.CreateUsers do
+  use Ecto.Migration
+
+  def change do
+    create table(:users) do
+      add :email, :string, null: false
+      add :hashed_password, :string, null: false
+      add :onboarded_at, :utc_datetime
+
+      timestamps()
+    end
+
+    create unique_index(:users, [:email])
+  end
+end


### PR DESCRIPTION
## Summary
- add `Users` schema and accounts context
- create auth plug for session checks
- implement registration, login, and onboarding LiveViews
- secure `/dashboard` and onboarding routes
- allow logout and migration for users

## Testing
- `mix format`
- `mix test` *(fails: requires Hex)*

------
https://chatgpt.com/codex/tasks/task_e_687a5f3a2a308331ba28ca3e6a116aaf