### PR TITLE
Fix compile errors and warnings

### DIFF
--- a/dashboard_gen/lib/dashboard_gen/gpt_client.ex
+++ b/dashboard_gen/lib/dashboard_gen/gpt_client.ex
@@ -10,10 +10,6 @@ defmodule DashboardGen.GPTClient do
 
   @openai_url "https://api.openai.com/v1/chat/completions"
 
-  @doc """
-  Sends the given prompt to the OpenAI API and returns the decoded chart
-  specification on success.
-  """
   defp clean_gpt_json(json) do
     json
     |> String.replace(~r/,\s*\n\s*}/, "\n}")

--- a/dashboard_gen/lib/dashboard_gen_web/live/register_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/register_live.html.heex
@@ -1,6 +1,6 @@
 <div class="max-w-md mx-auto mt-10">
   <h2 class="text-xl font-semibold mb-4">Register</h2>
-  <.form let={f} for={@changeset} phx-submit="save">
+  <.form :let={f} for={@changeset} phx-submit="save">
     <div class="mb-2">
       <%= label f, :email, class: "block" %>
       <%= email_input f, :email, class: "border px-2" %>


### PR DESCRIPTION
## Summary
- remove misplaced `@doc` from private function
- correct LiveView form attribute

## Testing
- `mix compile` *(fails: Mix requires the Hex package manager)*

------
https://chatgpt.com/codex/tasks/task_e_687a625328088331a6ac04c09c84e854