### PR TITLE
Fix missing helpers in RegisterLive

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/register_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/register_live.ex
@@ -1,5 +1,7 @@
 defmodule DashboardGenWeb.RegisterLive do
   use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :root}
+  use DashboardGenWeb, :html
+
   alias DashboardGen.Accounts
   alias DashboardGen.Accounts.User
 
@@ -19,5 +21,11 @@ defmodule DashboardGenWeb.RegisterLive do
       {:error, changeset} ->
         {:noreply, assign(socket, changeset: changeset)}
     end
+  end
+
+  defp error_tag(form, field) do
+    Enum.map(Keyword.get_values(form.errors, field), fn {message, _opts} ->
+      Phoenix.HTML.Tag.content_tag(:span, message, class: "text-red-600")
+    end)
   end
 end


### PR DESCRIPTION
## Summary
- include `DashboardGenWeb, :html` in RegisterLive for HTML form helpers
- add a private `error_tag/2` helper to render changeset errors

## Testing
- `mix compile` *(fails: Hex package manager is needed)*

------
https://chatgpt.com/codex/tasks/task_e_687a64da201c8331bf05c7a77dda1eda