### PR TITLE
Fix Auth plug undefined init

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/plugs/auth.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/plugs/auth.ex
@@ -1,13 +1,43 @@
 defmodule DashboardGenWeb.Plugs.Auth do
+  @moduledoc """
+  A collection of simple authentication plugs used throughout the router.
+
+  It can be invoked with `plug DashboardGenWeb.Plugs.Auth, :fetch_current_user`
+  or `plug DashboardGenWeb.Plugs.Auth, :require_authenticated`.
+  """
+
   import Plug.Conn
   import Phoenix.Controller
+
   alias DashboardGen.Accounts
 
+  @doc """
+  Callback required by `Plug` behaviour.
+  """
+  def init(action), do: action
+
+  @doc """
+  Dispatches to the appropriate plug based on the action.
+  """
+  def call(conn, action) do
+    case action do
+      :fetch_current_user -> fetch_current_user(conn, [])
+      :require_authenticated -> require_authenticated(conn, [])
+      _ -> conn
+    end
+  end
+
+  @doc """
+  Fetches the currently logged in user and assigns it to the connection.
+  """
   def fetch_current_user(conn, _opts) do
     user = get_session(conn, :user_id) && Accounts.get_user(get_session(conn, :user_id))
     assign(conn, :current_user, user)
   end
 
+  @doc """
+  Halts the request unless a user is assigned.
+  """
   def require_authenticated(%{assigns: %{current_user: nil}} = conn, _opts) do
     conn
     |> redirect(to: "/login")


### PR DESCRIPTION
## Summary
- implement `init/1` and `call/2` for `DashboardGenWeb.Plugs.Auth`
- document plug behaviours and dispatch logic

## Testing
- `mix test` *(fails: Mix requires Hex package manager)*

------
https://chatgpt.com/codex/tasks/task_e_687a691412a48331ba128194f1b1570a