### PR TITLE
Redirect unauthenticated users to login

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/router.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/router.ex
@@ -20,7 +20,6 @@ defmodule DashboardGenWeb.Router do
   scope "/", DashboardGenWeb do
     pipe_through(:browser)
 
-    live("/", DashboardLive)
     live("/register", RegisterLive)
     live("/login", LoginLive)
     delete("/logout", AuthController, :delete)
@@ -29,13 +28,9 @@ defmodule DashboardGenWeb.Router do
   scope "/", DashboardGenWeb do
     pipe_through([:browser, :require_auth])
 
+    live("/", DashboardLive)
     live("/dashboard", DashboardLive)
     live("/onboarding", OnboardingLive)
-  end
-
-  scope "/", DashboardGenWeb do
-    pipe_through(:browser)
-
     live("/saved", SavedLive)
     live("/settings", SettingsLive)
     live("/uploads", UploadsLive)


### PR DESCRIPTION
## Summary
- enforce auth for dashboard routes

## Testing
- `mix format lib/dashboard_gen_web/router.ex`
- `mix test` *(fails: Could not install Hex)*

------
https://chatgpt.com/codex/tasks/task_e_687a6cdaf72c8331a9f4b736071a9a2b