### PR TITLE
Add register button to login page

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/login_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/login_live.html.heex
@@ -13,5 +13,6 @@
       <input type="password" name="user[password]" class="border px-2" />
     </div>
     <button class="bg-blue-500 text-white px-4 py-2">Log In</button>
+    <Phoenix.Component.link navigate={~p"/register"} class="ml-4 bg-gray-500 text-white px-4 py-2">Register</Phoenix.Component.link>
   </form>
 </div>


### PR DESCRIPTION
## Summary
- improve onboarding by linking to the register page from login page

## Testing
- `mix test` *(fails: could not install Hex)*

------
https://chatgpt.com/codex/tasks/task_e_687a6f2c2e188331a46be88dcc1a1f12