### PR TITLE
Fix login page path generation

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/login_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/login_live.ex
@@ -1,5 +1,6 @@
 defmodule DashboardGenWeb.LoginLive do
   use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :root}
+  use DashboardGenWeb, :html
   alias DashboardGen.Accounts
 
   def mount(_params, _session, socket) do


### PR DESCRIPTION
## Summary
- include `DashboardGenWeb` helpers in LoginLive to enable `~p` path sigil

## Testing
- `mix test` *(fails: Hex could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_687a721bf09c8331b21da139234b16e4