### PR TITLE
Fix user schema for password fields

### DIFF
--- a/dashboard_gen/lib/dashboard_gen/accounts/user.ex
+++ b/dashboard_gen/lib/dashboard_gen/accounts/user.ex
@@ -6,6 +6,8 @@ defmodule DashboardGen.Accounts.User do
     field(:email, :string)
     field(:hashed_password, :string)
     field(:onboarded_at, :utc_datetime)
+    field(:password, :string, virtual: true)
+    field(:password_confirmation, :string, virtual: true)
 
     timestamps()
   end


### PR DESCRIPTION
## Summary
- add `:password` and `:password_confirmation` virtual fields to `User`

## Testing
- `mix deps.get` *(fails: could not download Hex)*

------
https://chatgpt.com/codex/tasks/task_e_687a746257d48331b2253ce84ecffd05