### PR TITLE
Redirect login flow to dashboard

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/login_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/login_live.ex
@@ -10,12 +10,10 @@ defmodule DashboardGenWeb.LoginLive do
   def handle_event("login", %{"user" => %{"email" => email, "password" => password}}, socket) do
     case Accounts.authenticate_user(email, password) do
       {:ok, user} ->
-        dest = if is_nil(user.onboarded_at), do: "/onboarding", else: "/dashboard"
-
         {:noreply,
          socket
          |> DashboardGenWeb.LiveHelpers.maybe_put_session(:user_id, user.id)
-         |> Phoenix.LiveView.push_navigate(to: dest)}
+         |> Phoenix.LiveView.push_navigate(to: "/dashboard")}
 
       :error ->
         {:noreply, assign(socket, error: "Invalid email or password")}


### PR DESCRIPTION
## Summary
- update login live view to always navigate to the dashboard after successful login

## Testing
- `mix test` *(fails: Mix requires the Hex package manager to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687a7a493f8c8331971527f85e085c0a