### PR TITLE
Add user dropdown to sidebar

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
@@ -19,8 +19,9 @@ defmodule DashboardGenWeb.DashboardLive do
        collapsed: false,
        summary: nil,
        explanation: nil,
-       alerts: nil
-     )}
+       alerts: nil,
+       show_user_menu: false
+      )}
   end
 
   @impl true
@@ -40,6 +41,14 @@ defmodule DashboardGenWeb.DashboardLive do
 
   def handle_event("toggle_sidebar", _params, socket) do
     {:noreply, update(socket, :collapsed, &(!&1))}
+  end
+
+  def handle_event("toggle_user_menu", _params, socket) do
+    {:noreply, update(socket, :show_user_menu, &(!&1))}
+  end
+
+  def handle_event("hide_user_menu", _params, socket) do
+    {:noreply, assign(socket, show_user_menu: false)}
   end
 
   def handle_event("generate_summary", _params, socket) do
@@ -225,6 +234,15 @@ defmodule DashboardGenWeb.DashboardLive do
     |> VegaLite.encode(:color, field: "category", type: :nominal)
   end
 
-  def sidebar_classes(true), do: "w-16 bg-gray-800 text-white transition-all"
-  def sidebar_classes(false), do: "w-64 bg-gray-800 text-white transition-all"
+  def sidebar_classes(true), do: "relative w-16 bg-gray-800 text-white transition-all"
+  def sidebar_classes(false), do: "relative w-64 bg-gray-800 text-white transition-all"
+
+  defp initials(nil), do: "?"
+  defp initials(email) when is_binary(email) do
+    email
+    |> String.split("@")
+    |> List.first()
+    |> String.slice(0, 2)
+    |> String.upcase()
+  end
 end

--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
@@ -21,6 +21,27 @@
         📁 <%= unless @collapsed, do: "Uploads" %>
       </Phoenix.Component.link>
     </nav>
+
+    <div class="absolute bottom-4 left-4" phx-click-away="hide_user_menu">
+      <div phx-click="toggle_user_menu" class="flex items-center space-x-2 cursor-pointer">
+        <div class="bg-gray-300 rounded-full h-8 w-8 flex items-center justify-center text-sm font-bold">
+          <%= initials(@current_user.name || @current_user.email) %>
+        </div>
+        <div :if={!@collapsed} class="text-sm">
+          <div class="font-medium"><%= @current_user.name || @current_user.email %></div>
+          <div class="text-gray-400 text-xs">Signed in</div>
+        </div>
+      </div>
+
+      <%= if @show_user_menu do %>
+        <div class="mt-2 w-48 bg-white shadow-lg border rounded text-sm">
+          <a href="/settings" class="block px-4 py-2 hover:bg-gray-100">⚙️ Settings</a>
+          <form method="post" action="/logout">
+            <button type="submit" class="w-full text-left px-4 py-2 hover:bg-gray-100">🚪 Log out</button>
+          </form>
+        </div>
+      <% end %>
+    </div>
   </aside>
 
   <main class="flex-1 flex flex-col justify-between overflow-y-auto">


### PR DESCRIPTION
## Summary
- show avatar and dropdown at the bottom of the sidebar
- support toggling the menu via LiveView events
- make sidebar `relative` for positioning
- helper to create avatar initials

## Testing
- `mix test --color --trace --warnings-as-errors` *(fails: Could not install Hex)*

------
https://chatgpt.com/codex/tasks/task_e_687a81d1a0488331a0e326b781cb5bbe