### PR TITLE
Fix login redirect and add error handling

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/login_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/login_live.ex
@@ -13,10 +13,13 @@ defmodule DashboardGenWeb.LoginLive do
         {:noreply,
          socket
          |> DashboardGenWeb.LiveHelpers.maybe_put_session(:user_id, user.id)
-         |> Phoenix.LiveView.push_navigate(to: "/dashboard")}
+         |> Phoenix.LiveView.redirect(to: "/")}
 
       :error ->
         {:noreply, assign(socket, error: "Invalid email or password")}
+
+      other ->
+        {:noreply, assign(socket, error: "Authentication error: #{inspect(other)}")}
     end
   end
 end

--- a/dashboard_gen/lib/dashboard_gen_web/live/onboarding_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/onboarding_live.ex
@@ -14,6 +14,6 @@ defmodule DashboardGenWeb.OnboardingLive do
 
   def handle_event("run_query", _params, socket) do
     Accounts.mark_onboarded(socket.assigns.user)
-    {:noreply, Phoenix.LiveView.push_navigate(socket, to: "/dashboard")}
+    {:noreply, Phoenix.LiveView.redirect(socket, to: "/")}
   end
 end


### PR DESCRIPTION
## Summary
- redirect to home on login success
- show errors for login failures
- send users to home after onboarding

## Testing
- `mix format`
- `mix test` *(fails: Hex package manager missing)*

------
https://chatgpt.com/codex/tasks/task_e_687a86dcb2548331b0edd50ed574fbd4