### PR TITLE
Fix login navigation to dashboard

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/components/layouts/dashboard.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/components/layouts/dashboard.html.heex
@@ -1,7 +1,7 @@
 <div class="flex min-h-screen">
   <aside class="w-60 bg-gray-800 text-white p-4 space-y-2">
     <nav class="flex flex-col space-y-2">
-      <Phoenix.Component.link navigate={~p"/"} class="hover:underline">Dashboard</Phoenix.Component.link>
+      <Phoenix.Component.link navigate={~p"/dashboard"} class="hover:underline">Dashboard</Phoenix.Component.link>
       <Phoenix.Component.link navigate={~p"/saved"} class="hover:underline">Saved Views</Phoenix.Component.link>
       <Phoenix.Component.link navigate={~p"/settings"} class="hover:underline">Settings</Phoenix.Component.link>
       <Phoenix.Component.link navigate={~p"/uploads"} class="hover:underline">Uploads</Phoenix.Component.link>

--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
@@ -8,7 +8,7 @@
     </div>
 
     <nav class="space-y-2 p-3">
-      <Phoenix.Component.link navigate={~p"/"} class="nav-item flex items-center gap-2 text-sm hover:underline">
+      <Phoenix.Component.link navigate={~p"/dashboard"} class="nav-item flex items-center gap-2 text-sm hover:underline">
         📊 <%= unless @collapsed, do: "Dashboard" %>
       </Phoenix.Component.link>
       <Phoenix.Component.link navigate={~p"/saved"} class="nav-item flex items-center gap-2 text-sm hover:underline">

--- a/dashboard_gen/lib/dashboard_gen_web/live/login_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/login_live.ex
@@ -13,7 +13,7 @@ defmodule DashboardGenWeb.LoginLive do
         {:noreply,
          socket
          |> DashboardGenWeb.LiveHelpers.maybe_put_session(:user_id, user.id)
-         |> Phoenix.LiveView.redirect(to: "/")}
+         |> Phoenix.LiveView.push_navigate(to: "/dashboard")}
 
       :error ->
         {:noreply, assign(socket, error: "Invalid email or password")}

--- a/dashboard_gen/lib/dashboard_gen_web/router.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/router.ex
@@ -20,6 +20,7 @@ defmodule DashboardGenWeb.Router do
   scope "/", DashboardGenWeb do
     pipe_through(:browser)
 
+    get("/", PageController, :home)
     live("/register", RegisterLive)
     live("/login", LoginLive)
     delete("/logout", AuthController, :delete)
@@ -28,7 +29,6 @@ defmodule DashboardGenWeb.Router do
   scope "/", DashboardGenWeb do
     pipe_through([:browser, :require_auth])
 
-    live("/", DashboardLive)
     live("/dashboard", DashboardLive)
     live("/onboarding", OnboardingLive)
     live("/saved", SavedLive)


### PR DESCRIPTION
## Summary
- expose a landing page at `/` and move the dashboard under `/dashboard`
- push navigate to `/dashboard` after successful login
- update navigation links to point to the new dashboard route

## Testing
- `mix format`
- `mix test` *(fails: requires Hex and internet access)*

------
https://chatgpt.com/codex/tasks/task_e_687a8dcdf40c83319b73a8a0b9eb3a4d