### PR TITLE
Refactor authentication controller-based

### DIFF
--- a/dashboard_gen/lib/dashboard_gen/accounts.ex
+++ b/dashboard_gen/lib/dashboard_gen/accounts.ex
@@ -5,6 +5,7 @@ defmodule DashboardGen.Accounts do
   alias DashboardGen.Accounts.User
 
   def get_user(id), do: Repo.get(User, id)
+  def get_user!(id), do: Repo.get!(User, id)
 
   def get_user_by_email(email) when is_binary(email) do
     Repo.get_by(User, email: email)

--- a/dashboard_gen/lib/dashboard_gen_web/controllers/auth_controller.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/controllers/auth_controller.ex
@@ -1,6 +1,22 @@
 defmodule DashboardGenWeb.AuthController do
   use DashboardGenWeb, :controller
 
+  alias DashboardGen.Accounts
+
+  def create(conn, %{"user" => %{"email" => email, "password" => password}}) do
+    case Accounts.authenticate_user(email, password) do
+      {:ok, user} ->
+        conn
+        |> put_session(:user_id, user.id)
+        |> redirect(to: if(user.onboarded_at, do: "/dashboard", else: "/onboarding"))
+
+      :error ->
+        conn
+        |> put_flash(:error, "Invalid email or password")
+        |> redirect(to: "/login")
+    end
+  end
+
   def delete(conn, _params) do
     conn
     |> configure_session(drop: true)

--- a/dashboard_gen/lib/dashboard_gen_web/live/login_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/login_live.ex
@@ -1,25 +1,8 @@
 defmodule DashboardGenWeb.LoginLive do
   use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :root}
   use DashboardGenWeb, :html
-  alias DashboardGen.Accounts
 
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, error: nil)}
-  end
-
-  def handle_event("login", %{"user" => %{"email" => email, "password" => password}}, socket) do
-    case Accounts.authenticate_user(email, password) do
-      {:ok, user} ->
-        {:noreply,
-         socket
-         |> DashboardGenWeb.LiveHelpers.maybe_put_session(:user_id, user.id)
-         |> Phoenix.LiveView.push_navigate(to: "/dashboard")}
-
-      :error ->
-        {:noreply, assign(socket, error: "Invalid email or password")}
-
-      other ->
-        {:noreply, assign(socket, error: "Authentication error: #{inspect(other)}")}
-    end
+    {:ok, socket}
   end
 end

--- a/dashboard_gen/lib/dashboard_gen_web/live/login_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/login_live.html.heex
@@ -1,9 +1,13 @@
 <div class="max-w-md mx-auto mt-10">
   <h2 class="text-xl font-semibold mb-4">Log In</h2>
-  <%= if @error do %>
-    <div class="text-red-600 mb-2"><%= @error %></div>
+  <%= if live_flash(@flash, :error) do %>
+    <div class="text-red-600 mb-2"><%= live_flash(@flash, :error) %></div>
   <% end %>
-  <form phx-submit="login">
+  <%= if live_flash(@flash, :info) do %>
+    <div class="text-green-600 mb-2"><%= live_flash(@flash, :info) %></div>
+  <% end %>
+  <form action={~p"/login"} method="post">
+    <input type="hidden" name="_csrf_token" value={Plug.CSRFProtection.get_csrf_token()} />
     <div class="mb-2">
       <label class="block">Email</label>
       <input type="email" name="user[email]" class="border px-2" />

--- a/dashboard_gen/lib/dashboard_gen_web/live/register_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/register_live.ex
@@ -12,11 +12,11 @@ defmodule DashboardGenWeb.RegisterLive do
 
   def handle_event("save", %{"user" => user_params}, socket) do
     case Accounts.create_user(user_params) do
-      {:ok, user} ->
+      {:ok, _user} ->
         {:noreply,
          socket
-         |> DashboardGenWeb.LiveHelpers.maybe_put_session(:user_id, user.id)
-         |> Phoenix.LiveView.push_navigate(to: "/onboarding")}
+         |> put_flash(:info, "Account created, please log in.")
+         |> Phoenix.LiveView.push_navigate(to: "/login")}
 
       {:error, changeset} ->
         {:noreply, assign(socket, changeset: changeset)}

--- a/dashboard_gen/lib/dashboard_gen_web/router.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/router.ex
@@ -23,6 +23,7 @@ defmodule DashboardGenWeb.Router do
     get("/", PageController, :home)
     live("/register", RegisterLive)
     live("/login", LoginLive)
+    post("/login", AuthController, :create)
     delete("/logout", AuthController, :delete)
   end
 


### PR DESCRIPTION
## Summary
- handle login through `AuthController.create/2`
- submit login form via HTTP POST
- redirect after registration to the login page
- define `Accounts.get_user!/1`
- expose POST route for login

## Testing
- `mix test` *(fails: requires Hex and can't be installed)*

------
https://chatgpt.com/codex/tasks/task_e_687a980ff6fc8331980fc86f52209129