### PR TITLE
Fix CSRF handling in login form

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/login_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/login_live.ex
@@ -3,6 +3,7 @@ defmodule DashboardGenWeb.LoginLive do
   use DashboardGenWeb, :html
 
   def mount(_params, _session, socket) do
-    {:ok, socket}
+    csrf_token = Plug.CSRFProtection.get_csrf_token()
+    {:ok, assign(socket, csrf_token: csrf_token)}
   end
 end

--- a/dashboard_gen/lib/dashboard_gen_web/live/login_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/login_live.html.heex
@@ -7,7 +7,7 @@
     <div class="text-green-600 mb-2"><%= live_flash(@flash, :info) %></div>
   <% end %>
   <form action={~p"/login"} method="post">
-    <input type="hidden" name="_csrf_token" value={Plug.CSRFProtection.get_csrf_token()} />
+    <input type="hidden" name="_csrf_token" value={@csrf_token} />
     <div class="mb-2">
       <label class="block">Email</label>
       <input type="email" name="user[email]" class="border px-2" />


### PR DESCRIPTION
## Summary
- assign CSRF token in `LoginLive.mount/3`
- use the assigned value in the login form

## Testing
- `mix test` *(fails: requires Hex and internet)*

------
https://chatgpt.com/codex/tasks/task_e_687a9c29029c8331a78f0dc5cd35d926