### PR TITLE
Implement ChatGPT-style responsive layout

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/components/layouts.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/components/layouts.ex
@@ -1,5 +1,8 @@
 defmodule DashboardGenWeb.Layouts do
   use DashboardGenWeb, :html
 
+  import DashboardGenWeb.SidebarComponent
+  import DashboardGenWeb.TopbarComponent
+
   embed_templates("layouts/*")
 end

--- a/dashboard_gen/lib/dashboard_gen_web/components/layouts/dashboard.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/components/layouts/dashboard.html.heex
@@ -1,21 +1,9 @@
-<div class="flex min-h-screen">
-  <aside class="w-60 bg-gray-800 text-white p-4 space-y-2">
-    <nav class="flex flex-col space-y-2">
-      <Phoenix.Component.link navigate={~p"/"} class="hover:underline">Dashboard</Phoenix.Component.link>
-      <Phoenix.Component.link navigate={~p"/saved"} class="hover:underline">Saved Views</Phoenix.Component.link>
-      <Phoenix.Component.link navigate={~p"/settings"} class="hover:underline">Settings</Phoenix.Component.link>
-      <Phoenix.Component.link navigate={~p"/uploads"} class="hover:underline">Uploads</Phoenix.Component.link>
-    </nav>
-  </aside>
-
+<div class="flex min-h-screen bg-gray-50 text-gray-800 font-sans text-sm">
+  <.sidebar collapsed={@collapsed} />
   <div class="flex-1 flex flex-col">
-    <header class="p-4 bg-gray-100 border-b">
-      <h1 class="text-xl font-semibold">DashboardGen</h1>
-    </header>
-
-    <main class="flex-1 overflow-y-auto p-4 pb-24">
+    <.topbar collapsed={@collapsed} />
+    <main class="flex-1 px-6 py-4">
       <%= @inner_content %>
     </main>
   </div>
 </div>
-

--- a/dashboard_gen/lib/dashboard_gen_web/components/sidebar_component.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/components/sidebar_component.ex
@@ -1,0 +1,39 @@
+defmodule DashboardGenWeb.SidebarComponent do
+  use DashboardGenWeb, :html
+
+  attr(:collapsed, :boolean, default: false)
+
+  def sidebar(assigns) do
+    ~H"""
+    <aside
+      class={[
+        "bg-white border-r transition-all transform duration-200 flex flex-col md:translate-x-0",
+        "absolute inset-y-0 left-0 z-20 md:static",
+        @collapsed && "-translate-x-full md:w-16",
+        !@collapsed && "translate-x-0 w-60"
+      ]}
+    >
+      <div class="flex items-center justify-between px-4 py-3 border-b">
+        <span :if={!@collapsed} class="font-semibold">DashboardGen</span>
+        <button phx-click="toggle_sidebar" class="text-gray-500" aria-label="Toggle sidebar">
+          <%= if @collapsed, do: "▶", else: "◀" %>
+        </button>
+      </div>
+      <nav class="flex-1 p-2 space-y-1">
+        <Phoenix.Component.link navigate={~p"/"} class="flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-md">
+          📊 <span :if={!@collapsed}>Dashboard</span>
+        </Phoenix.Component.link>
+        <Phoenix.Component.link navigate={~p"/saved"} class="flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-md">
+          💾 <span :if={!@collapsed}>Saved Views</span>
+        </Phoenix.Component.link>
+        <Phoenix.Component.link navigate={~p"/settings"} class="flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-md">
+          ⚙️ <span :if={!@collapsed}>Settings</span>
+        </Phoenix.Component.link>
+        <Phoenix.Component.link navigate={~p"/uploads"} class="flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-md">
+          📁 <span :if={!@collapsed}>Uploads</span>
+        </Phoenix.Component.link>
+      </nav>
+    </aside>
+    """
+  end
+end

--- a/dashboard_gen/lib/dashboard_gen_web/components/topbar_component.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/components/topbar_component.ex
@@ -1,0 +1,14 @@
+defmodule DashboardGenWeb.TopbarComponent do
+  use DashboardGenWeb, :html
+
+  attr(:collapsed, :boolean, default: false)
+
+  def topbar(assigns) do
+    ~H"""
+    <div class="md:hidden flex items-center justify-between px-4 py-3 border-b bg-white">
+      <button phx-click="toggle_sidebar" aria-label="Open sidebar" class="text-xl">☰</button>
+      <span class="font-semibold">DashboardGen</span>
+    </div>
+    """
+  end
+end

--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
@@ -1,5 +1,5 @@
 defmodule DashboardGenWeb.DashboardLive do
-  use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :root}
+  use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :dashboard}
   use DashboardGenWeb, :html
   import DashboardGenWeb.CoreComponents
   alias DashboardGen.GPTClient

--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
@@ -1,33 +1,8 @@
-<div class="flex h-screen">
-  <aside class={sidebar_classes(@collapsed)}>
-    <div class="flex justify-between items-center p-3 border-b">
-      <span :if={!@collapsed} class="text-lg font-semibold">DashboardGen</span>
-      <button phx-click="toggle_sidebar" aria-label="Toggle sidebar">
-        <%= if @collapsed, do: "▶", else: "◀" %>
-      </button>
-    </div>
-
-    <nav class="space-y-2 p-3">
-      <Phoenix.Component.link navigate={~p"/"} class="nav-item flex items-center gap-2 text-sm hover:underline">
-        📊 <%= unless @collapsed, do: "Dashboard" %>
-      </Phoenix.Component.link>
-      <Phoenix.Component.link navigate={~p"/saved"} class="nav-item flex items-center gap-2 text-sm hover:underline">
-        💾 <%= unless @collapsed, do: "Saved Views" %>
-      </Phoenix.Component.link>
-      <Phoenix.Component.link navigate={~p"/settings"} class="nav-item flex items-center gap-2 text-sm hover:underline">
-        ⚙️ <%= unless @collapsed, do: "Settings" %>
-      </Phoenix.Component.link>
-      <Phoenix.Component.link navigate={~p"/uploads"} class="nav-item flex items-center gap-2 text-sm hover:underline">
-        📁 <%= unless @collapsed, do: "Uploads" %>
-      </Phoenix.Component.link>
-    </nav>
-  </aside>
-
-  <main class="flex-1 flex flex-col justify-between overflow-y-auto">
-    <div class="p-6 space-y-6 overflow-y-auto">
-      <%= if live_flash(@flash, :error) do %>
-        <div class="text-red-600"><%= live_flash(@flash, :error) %></div>
-      <% end %>
+<div class="flex flex-col h-full justify-between">
+  <div class="space-y-6 overflow-y-auto">
+    <%= if live_flash(@flash, :error) do %>
+      <div class="text-red-600"><%= live_flash(@flash, :error) %></div>
+    <% end %>
 
     <%= if @loading do %>
       <div class="text-gray-500">Generating...</div>
@@ -65,19 +40,17 @@
         <strong>Explanation:</strong> <%= @explanation %>
       </div>
     <% end %>
+  </div>
+
+  <form phx-submit="generate" class="p-6 bg-white border-t">
+    <div class="flex items-end gap-2 border border-gray-300 rounded-xl shadow-sm p-3 bg-white">
+      <textarea
+        name="prompt"
+        rows="1"
+        placeholder="Describe your query..."
+        class="flex-1 resize-none rounded-md border-none outline-none focus:ring-0 text-sm"
+      ></textarea>
+      <button type="submit" class="bg-black text-white rounded-full px-3 py-1 text-sm">➤</button>
     </div>
-
-    <form phx-submit="generate" class="p-6 bg-white border-t">
-      <div class="flex items-end gap-2 border border-gray-300 rounded-xl shadow-sm p-3 bg-white">
-        <textarea
-          name="prompt"
-          rows="1"
-          placeholder="Describe your query..."
-          class="flex-1 resize-none rounded-md border-none outline-none focus:ring-0 text-sm"
-        ></textarea>
-        <button type="submit" class="bg-black text-white rounded-full px-3 py-1 text-sm">➤</button>
-      </div>
-    </form>
-  </main>
+  </form>
 </div>
-

--- a/dashboard_gen/lib/dashboard_gen_web/live/login_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/login_live.ex
@@ -1,10 +1,10 @@
 defmodule DashboardGenWeb.LoginLive do
-  use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :root}
+  use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :dashboard}
   use DashboardGenWeb, :html
   alias DashboardGen.Accounts
 
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, error: nil)}
+    {:ok, assign(socket, error: nil, collapsed: false)}
   end
 
   def handle_event("login", %{"user" => %{"email" => email, "password" => password}}, socket) do
@@ -18,5 +18,9 @@ defmodule DashboardGenWeb.LoginLive do
       :error ->
         {:noreply, assign(socket, error: "Invalid email or password")}
     end
+  end
+
+  def handle_event("toggle_sidebar", _params, socket) do
+    {:noreply, update(socket, :collapsed, &(!&1))}
   end
 end

--- a/dashboard_gen/lib/dashboard_gen_web/live/onboarding_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/onboarding_live.ex
@@ -1,12 +1,12 @@
 defmodule DashboardGenWeb.OnboardingLive do
-  use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :root}
+  use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :dashboard}
   alias DashboardGen.Accounts
 
   def mount(_params, session, socket) do
     user = session["user_id"] && Accounts.get_user(session["user_id"])
 
     if user do
-      {:ok, assign(socket, user: user)}
+      {:ok, assign(socket, user: user, collapsed: false)}
     else
       {:ok, Phoenix.LiveView.redirect(socket, to: "/login")}
     end
@@ -15,5 +15,9 @@ defmodule DashboardGenWeb.OnboardingLive do
   def handle_event("run_query", _params, socket) do
     Accounts.mark_onboarded(socket.assigns.user)
     {:noreply, Phoenix.LiveView.push_navigate(socket, to: "/dashboard")}
+  end
+
+  def handle_event("toggle_sidebar", _params, socket) do
+    {:noreply, update(socket, :collapsed, &(!&1))}
   end
 end

--- a/dashboard_gen/lib/dashboard_gen_web/live/register_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/register_live.ex
@@ -1,5 +1,5 @@
 defmodule DashboardGenWeb.RegisterLive do
-  use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :root}
+  use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :dashboard}
   use DashboardGenWeb, :html
 
   alias DashboardGen.Accounts
@@ -7,7 +7,7 @@ defmodule DashboardGenWeb.RegisterLive do
 
   def mount(_params, _session, socket) do
     changeset = User.registration_changeset(%User{}, %{})
-    {:ok, assign(socket, changeset: changeset)}
+    {:ok, assign(socket, changeset: changeset, collapsed: false)}
   end
 
   def handle_event("save", %{"user" => user_params}, socket) do
@@ -21,6 +21,10 @@ defmodule DashboardGenWeb.RegisterLive do
       {:error, changeset} ->
         {:noreply, assign(socket, changeset: changeset)}
     end
+  end
+
+  def handle_event("toggle_sidebar", _params, socket) do
+    {:noreply, update(socket, :collapsed, &(!&1))}
   end
 
   defp error_tag(form, field) do

--- a/dashboard_gen/lib/dashboard_gen_web/live/saved_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/saved_live.ex
@@ -4,6 +4,10 @@ defmodule DashboardGenWeb.SavedLive do
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, :page_title, "Saved Views")}
+    {:ok, assign(socket, page_title: "Saved Views", collapsed: false)}
+  end
+
+  def handle_event("toggle_sidebar", _params, socket) do
+    {:noreply, update(socket, :collapsed, &(!&1))}
   end
 end

--- a/dashboard_gen/lib/dashboard_gen_web/live/settings_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/settings_live.ex
@@ -4,6 +4,10 @@ defmodule DashboardGenWeb.SettingsLive do
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, :page_title, "Settings")}
+    {:ok, assign(socket, page_title: "Settings", collapsed: false)}
+  end
+
+  def handle_event("toggle_sidebar", _params, socket) do
+    {:noreply, update(socket, :collapsed, &(!&1))}
   end
 end

--- a/dashboard_gen/lib/dashboard_gen_web/live/uploads_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/uploads_live.ex
@@ -12,6 +12,7 @@ defmodule DashboardGenWeb.UploadsLive do
       |> assign(:uploads_list, Uploads.list_uploads())
       |> assign(:label, "")
       |> assign(:uploading?, false)
+      |> assign(:collapsed, false)
       |> allow_upload(:csv,
         accept: ~w(.csv),
         max_entries: 1,
@@ -29,6 +30,10 @@ defmodule DashboardGenWeb.UploadsLive do
 
   @impl true
   def handle_event("noop", _params, socket), do: {:noreply, socket}
+
+  def handle_event("toggle_sidebar", _params, socket) do
+    {:noreply, update(socket, :collapsed, &(!&1))}
+  end
 
   @impl true
   def handle_progress(:csv, entry, socket) when entry.done? do


### PR DESCRIPTION
## Summary
- add new dashboard layout with sidebar and topbar
- implement `<.sidebar>` and `<.topbar>` components
- update live views to use the new layout and support sidebar toggle

## Testing
- `mix format`
- `mix test` *(fails: Could not find an SCM for dependency :phoenix)*

------
https://chatgpt.com/codex/tasks/task_e_687ab4e67d448331af48117016df968d