### PR TITLE
Update LiveView layouts

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/components/layouts/dashboard.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/components/layouts/dashboard.html.heex
@@ -2,7 +2,7 @@
   <.sidebar collapsed={@collapsed} />
   <div class="flex-1 flex flex-col">
     <.topbar collapsed={@collapsed} />
-    <main class="flex-1 px-6 py-4">
+    <main class="flex-1 px-6 py-4 overflow-y-auto">
       <%= @inner_content %>
     </main>
   </div>

--- a/dashboard_gen/lib/dashboard_gen_web/components/layouts/root.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/components/layouts/root.html.heex
@@ -10,7 +10,7 @@
     <script src="https://cdn.jsdelivr.net/npm/vega-lite@5" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/vega-embed@6" defer></script>
   </head>
-  <body>
+  <body class="bg-gray-50 text-gray-800 font-sans text-sm">
     <%= @inner_content %>
     <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}></script>
   </body>

--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
@@ -13,6 +13,7 @@ defmodule DashboardGenWeb.DashboardLive do
   def mount(_params, _session, socket) do
     {:ok,
      assign(socket,
+       page_title: "Dashboard",
        prompt: "",
        chart_spec: nil,
        loading: false,
@@ -224,7 +225,4 @@ defmodule DashboardGenWeb.DashboardLive do
     |> VegaLite.encode(:y, field: "value", type: :quantitative)
     |> VegaLite.encode(:color, field: "category", type: :nominal)
   end
-
-  def sidebar_classes(true), do: "w-16 bg-gray-800 text-white transition-all"
-  def sidebar_classes(false), do: "w-64 bg-gray-800 text-white transition-all"
 end

--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
@@ -1,7 +1,8 @@
 <div class="flex flex-col h-full justify-between">
   <div class="space-y-6 overflow-y-auto">
+    <h1 class="text-xl font-semibold mb-4"><%= @page_title %></h1>
     <%= if live_flash(@flash, :error) do %>
-      <div class="text-red-600"><%= live_flash(@flash, :error) %></div>
+      <div class="rounded-md border p-4 bg-white shadow-sm text-red-600"><%= live_flash(@flash, :error) %></div>
     <% end %>
 
     <%= if @loading do %>
@@ -9,7 +10,7 @@
     <% end %>
 
     <%= if @alerts do %>
-      <div class="bg-yellow-50 border-l-4 border-yellow-400 text-yellow-900 p-4 rounded text-sm">
+      <div class="rounded-md border p-4 bg-white shadow-sm bg-yellow-50 border-yellow-400 text-yellow-900">
         <strong>⚠️ Alert:</strong>
         <ul class="list-disc pl-6 space-y-1 text-sm text-yellow-900">
           <%= for line <- String.split(@alerts, "\n", trim: true) do %>
@@ -31,12 +32,12 @@
     <% end %>
 
     <%= if @summary do %>
-      <div class="bg-gray-50 p-4 rounded text-sm text-gray-700">
+      <div class="rounded-md border p-4 bg-white shadow-sm text-gray-700">
         <strong>Insight:</strong> <%= @summary %>
       </div>
     <% end %>
     <%= if @explanation do %>
-      <div class="bg-yellow-50 p-4 rounded mt-4 text-sm text-yellow-900">
+      <div class="rounded-md border p-4 bg-white shadow-sm mt-4 text-yellow-900">
         <strong>Explanation:</strong> <%= @explanation %>
       </div>
     <% end %>

--- a/dashboard_gen/lib/dashboard_gen_web/live/login_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/login_live.ex
@@ -4,7 +4,7 @@ defmodule DashboardGenWeb.LoginLive do
   alias DashboardGen.Accounts
 
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, error: nil, collapsed: false)}
+    {:ok, assign(socket, error: nil, collapsed: false, page_title: "Login")}
   end
 
   def handle_event("login", %{"user" => %{"email" => email, "password" => password}}, socket) do

--- a/dashboard_gen/lib/dashboard_gen_web/live/login_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/login_live.html.heex
@@ -1,9 +1,9 @@
-<div class="max-w-md mx-auto mt-10">
-  <h2 class="text-xl font-semibold mb-4">Log In</h2>
+<div class="max-w-md mx-auto mt-10 space-y-4">
+  <h1 class="text-xl font-semibold mb-4"><%= @page_title %></h1>
   <%= if @error do %>
-    <div class="text-red-600 mb-2"><%= @error %></div>
+    <div class="rounded-md border p-4 bg-white shadow-sm text-red-600"><%= @error %></div>
   <% end %>
-  <form phx-submit="login">
+  <form phx-submit="login" class="space-y-2">
     <div class="mb-2">
       <label class="block">Email</label>
       <input type="email" name="user[email]" class="border px-2" />

--- a/dashboard_gen/lib/dashboard_gen_web/live/onboarding_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/onboarding_live.ex
@@ -6,7 +6,7 @@ defmodule DashboardGenWeb.OnboardingLive do
     user = session["user_id"] && Accounts.get_user(session["user_id"])
 
     if user do
-      {:ok, assign(socket, user: user, collapsed: false)}
+      {:ok, assign(socket, user: user, collapsed: false, page_title: "Onboarding")}
     else
       {:ok, Phoenix.LiveView.redirect(socket, to: "/login")}
     end

--- a/dashboard_gen/lib/dashboard_gen_web/live/onboarding_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/onboarding_live.html.heex
@@ -1,5 +1,5 @@
 <div class="max-w-md mx-auto mt-10 space-y-4">
-  <h2 class="text-xl font-semibold">Welcome to DashboardGen!</h2>
+  <h1 class="text-xl font-semibold mb-4"><%= @page_title %></h1>
   <p>Try running your first query:</p>
   <form phx-submit="run_query">
     <input type="text" name="query" class="border px-2 mr-2" />

--- a/dashboard_gen/lib/dashboard_gen_web/live/register_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/register_live.ex
@@ -7,7 +7,7 @@ defmodule DashboardGenWeb.RegisterLive do
 
   def mount(_params, _session, socket) do
     changeset = User.registration_changeset(%User{}, %{})
-    {:ok, assign(socket, changeset: changeset, collapsed: false)}
+    {:ok, assign(socket, changeset: changeset, collapsed: false, page_title: "Register")}
   end
 
   def handle_event("save", %{"user" => user_params}, socket) do

--- a/dashboard_gen/lib/dashboard_gen_web/live/register_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/register_live.html.heex
@@ -1,6 +1,6 @@
-<div class="max-w-md mx-auto mt-10">
-  <h2 class="text-xl font-semibold mb-4">Register</h2>
-  <.form :let={f} for={@changeset} phx-submit="save">
+<div class="max-w-md mx-auto mt-10 space-y-4">
+  <h1 class="text-xl font-semibold mb-4"><%= @page_title %></h1>
+  <.form :let={f} for={@changeset} phx-submit="save" class="space-y-2">
     <div class="mb-2">
       <%= label f, :email, class: "block" %>
       <%= email_input f, :email, class: "border px-2" %>

--- a/dashboard_gen/lib/dashboard_gen_web/live/saved_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/saved_live.html.heex
@@ -1,4 +1,4 @@
 <div>
-  <h2 class="text-lg font-semibold mb-4">Saved Views</h2>
+  <h1 class="text-xl font-semibold mb-4"><%= @page_title %></h1>
   <p>This page will list saved dashboards in the future.</p>
 </div>

--- a/dashboard_gen/lib/dashboard_gen_web/live/settings_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/settings_live.html.heex
@@ -1,4 +1,4 @@
 <div>
-  <h2 class="text-lg font-semibold mb-4">Settings</h2>
+  <h1 class="text-xl font-semibold mb-4"><%= @page_title %></h1>
   <p>This page will contain application settings.</p>
 </div>

--- a/dashboard_gen/lib/dashboard_gen_web/live/uploads_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/uploads_live.ex
@@ -9,6 +9,7 @@ defmodule DashboardGenWeb.UploadsLive do
   def mount(_params, _session, socket) do
     socket =
       socket
+      |> assign(:page_title, "Uploads")
       |> assign(:uploads_list, Uploads.list_uploads())
       |> assign(:label, "")
       |> assign(:uploading?, false)

--- a/dashboard_gen/lib/dashboard_gen_web/live/uploads_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/uploads_live.html.heex
@@ -1,31 +1,32 @@
-<h2 class="text-lg font-semibold mb-4">Upload CSV Dataset</h2>
-
-<.form id="upload-form" phx-change="validate" phx-submit="noop" multipart={true} class="space-y-2">
-  <input
-    type="text"
-    name="label"
-    value={@label}
-    placeholder="Optional label"
-    class="border rounded px-2 py-1"
-  />
-
-  <div phx-drop-target={@uploads.csv.ref}>
-    <.live_file_input
-      upload={@uploads.csv}
-      class="mt-2"
-      disabled={@uploading?}
+<h1 class="text-xl font-semibold mb-4"><%= @page_title %></h1>
+<div class="rounded-md border p-4 bg-white shadow-sm mb-4">
+  <.form id="upload-form" phx-change="validate" phx-submit="noop" multipart={true} class="space-y-2">
+    <input
+      type="text"
+      name="label"
+      value={@label}
+      placeholder="Optional label"
+      class="border rounded px-2 py-1"
     />
-  </div>
 
-  <%= for entry <- @uploads.csv.entries do %>
-    <progress value={entry.progress} max="100" class="w-full mt-2"></progress>
-  <% end %>
-</.form>
+    <div phx-drop-target={@uploads.csv.ref}>
+      <.live_file_input
+        upload={@uploads.csv}
+        class="mt-2"
+        disabled={@uploading?}
+      />
+    </div>
 
-<div class="mt-6">
-  <h3 class="font-medium mb-2">Uploaded Datasets</h3>
+    <%= for entry <- @uploads.csv.entries do %>
+      <progress value={entry.progress} max="100" class="w-full mt-2"></progress>
+    <% end %>
+  </.form>
+</div>
+
+<div class="mt-6 space-y-4">
+  <h3 class="font-medium">Uploaded Datasets</h3>
   <%= for upload <- @uploads_list do %>
-    <div class="mb-4 border p-2 rounded">
+    <div class="rounded-md border p-4 bg-white shadow-sm">
       <div class="font-semibold"><%= upload.name %></div>
       <div class="text-sm text-gray-500">
         Headers: <%= Enum.join(Map.keys(upload.headers), ", ") %>

--- a/dashboard_gen/lib/dashboard_gen_web/templates/layout/root.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/templates/layout/root.html.heex
@@ -7,7 +7,7 @@
     <%= live_title_tag assigns[:page_title] || "DashboardGen" %>
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
   </head>
-  <body>
+  <body class="bg-gray-50 text-gray-800 font-sans text-sm">
     <%= @inner_content %>
     <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}></script>
   </body>

--- a/dashboard_gen/lib/dashboard_gen_web/templates/page/index.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/templates/page/index.html.heex
@@ -1,1 +1,1 @@
-<h1>Welcome to DashboardGen</h1>
+<h1 class="text-xl font-semibold mb-4">Welcome to DashboardGen</h1>


### PR DESCRIPTION
## Summary
- add global gray background and fonts
- tweak dashboard layout main container
- add `page_title` to each LiveView
- standardize headings and card styling across templates

## Testing
- `mix test` *(fails: Mix requires the Hex package manager)*

------
https://chatgpt.com/codex/tasks/task_e_687ab90b812483318241eedcc936b4dd