### PR TITLE
Fix missing component imports in dashboard_live

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.ex
@@ -2,6 +2,7 @@ defmodule DashboardGenWeb.DashboardLive do
   use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :dashboard}
   use DashboardGenWeb, :html
   import DashboardGenWeb.CoreComponents
+  import DashboardGenWeb.LayoutComponents
   alias DashboardGen.GPTClient
   alias DashboardGen.Codex.Summarizer
   alias DashboardGen.Codex.Explainer


### PR DESCRIPTION
## Summary
- import layout components in `DashboardLive`

## Testing
- `mix compile` *(fails: requires Hex install)*

------
https://chatgpt.com/codex/tasks/task_e_687acaf10e748331bb1acf0c2bac191b