### PR TITLE
Apply ChatGPT-style Tailwind to LiveViews

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
@@ -10,35 +10,39 @@
     <% end %>
 
     <%= if @alerts do %>
-      <.alert_banner alerts={@alerts} />
+      <div class="mb-4">
+        <.alert_banner alerts={@alerts} />
+      </div>
     <% end %>
 
     <%= if @chart_spec do %>
-      <div id="chart-container" phx-hook="VegaLiteChart" phx-update="ignore" data-spec={@chart_spec} />
+      <div class="bg-white rounded-md shadow-sm p-4">
+        <h2 class="text-sm font-semibold mb-4">Top 5 Performing Campaigns</h2>
+        <div id="chart-container" phx-hook="VegaLiteChart" phx-update="ignore" data-spec={@chart_spec} />
+      </div>
       <.insight_buttons summary={@summary} loading={@loading} />
     <% end %>
 
     <%= if @summary do %>
-      <div class="rounded-md border p-4 bg-white shadow-sm text-gray-700">
+      <div class="bg-white rounded-md shadow-sm p-4 mb-4 text-gray-800 text-sm leading-relaxed">
         <strong>Insight:</strong> <%= @summary %>
       </div>
     <% end %>
     <%= if @explanation do %>
-      <div class="rounded-md border p-4 bg-white shadow-sm mt-4 text-yellow-900">
+      <div class="bg-white rounded-md shadow-sm p-4 mb-4 text-gray-800 text-sm leading-relaxed">
         <strong>Explanation:</strong> <%= @explanation %>
       </div>
     <% end %>
   </div>
 
-  <form phx-submit="generate" class="p-6 bg-white border-t">
-    <div class="flex items-end gap-2 border border-gray-300 rounded-xl shadow-sm p-3 bg-white">
-      <textarea
-        name="prompt"
-        rows="1"
-        placeholder="Describe your query..."
-        class="flex-1 resize-none rounded-md border-none outline-none focus:ring-0 text-sm"
-      ></textarea>
-      <button type="submit" class="bg-black text-white rounded-full px-3 py-1 text-sm">➤</button>
-    </div>
+  <form phx-submit="generate" class="bg-white border rounded-md flex items-center px-4 py-2 shadow-sm mt-6">
+    <input
+      type="text"
+      name="prompt"
+      value={@prompt}
+      placeholder="Describe your query..."
+      class="flex-1 bg-transparent outline-none text-sm"
+    />
+    <button type="submit" class="text-gray-600 hover:text-gray-800 p-2">➤</button>
   </form>
 </div>

--- a/dashboard_gen/lib/dashboard_gen_web/live/saved_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/saved_live.html.heex
@@ -1,4 +1,2 @@
-<div>
-  <h1 class="text-xl font-semibold mb-4"><%= @page_title %></h1>
-  <p>This page will list saved dashboards in the future.</p>
-</div>
+<h1 class="text-xl font-semibold mb-4"><%= @page_title %></h1>
+<p class="text-gray-400 text-center py-12">No saved views available yet.</p>

--- a/dashboard_gen/lib/dashboard_gen_web/live/settings_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/settings_live.html.heex
@@ -1,4 +1,2 @@
-<div>
-  <h1 class="text-xl font-semibold mb-4"><%= @page_title %></h1>
-  <p>This page will contain application settings.</p>
-</div>
+<h1 class="text-xl font-semibold mb-4"><%= @page_title %></h1>
+<p class="text-gray-400 text-center py-12">Settings coming soon.</p>

--- a/dashboard_gen/lib/dashboard_gen_web/live/uploads_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/uploads_live.html.heex
@@ -1,12 +1,12 @@
 <h1 class="text-xl font-semibold mb-4"><%= @page_title %></h1>
-<div class="rounded-md border p-4 bg-white shadow-sm mb-4">
+<div class="bg-white rounded-md shadow-sm p-4 mb-6 border">
   <.form id="upload-form" phx-change="validate" phx-submit="noop" multipart={true} class="space-y-2">
     <input
       type="text"
       name="label"
       value={@label}
       placeholder="Optional label"
-      class="border rounded px-2 py-1"
+      class="text-sm border rounded px-2 py-1"
     />
 
     <div phx-drop-target={@uploads.csv.ref}>
@@ -20,15 +20,16 @@
     <%= for entry <- @uploads.csv.entries do %>
       <progress value={entry.progress} max="100" class="w-full mt-2"></progress>
     <% end %>
+    <button type="submit" class="rounded-full bg-green-600 text-white text-sm px-4 py-1 hover:bg-green-500" disabled={@uploading?}>Upload</button>
   </.form>
 </div>
 
 <div class="mt-6 space-y-4">
   <h3 class="font-medium">Uploaded Datasets</h3>
   <%= for upload <- @uploads_list do %>
-    <div class="rounded-md border p-4 bg-white shadow-sm">
-      <div class="font-semibold"><%= upload.name %></div>
-      <div class="text-sm text-gray-500">
+    <div class="bg-white rounded-md shadow-sm p-4 mb-4 border">
+      <div class="text-sm font-medium"><%= upload.name %></div>
+      <div class="text-xs text-gray-500">
         Headers: <%= Enum.join(Map.keys(upload.headers), ", ") %>
       </div>
       <table class="mt-2 text-sm min-w-full">


### PR DESCRIPTION
## Summary
- style Dashboard page with alert banner, chart container, insight sections, and streamlined prompt form
- refresh Uploads page with modern card layout and submit button
- add friendly placeholders to Saved Views and Settings pages

## Testing
- `mix format`
- `mix test` *(fails: could not install Hex)*

------
https://chatgpt.com/codex/tasks/task_e_687ad74308588331b12a695a0b4cee04