### PR TITLE
Add Competitor Insights LiveView

### DIFF
--- a/dashboard_gen/lib/dashboard_gen/insights.ex
+++ b/dashboard_gen/lib/dashboard_gen/insights.ex
@@ -1,0 +1,37 @@
+defmodule DashboardGen.Insights do
+  @moduledoc """
+  Provides helper functions for working with competitor insights.
+  """
+
+  import Ecto.Query, warn: false
+  alias DashboardGen.Repo
+  alias DashboardGen.Scrapers.Insight
+
+  @doc """
+  Returns insights grouped by company. Each company will include the
+  most recent `limit` press releases based on the `inserted_at` timestamp
+  of the Insight record.
+  """
+  def list_recent_insights_by_company(limit \\ 10) do
+    Insight
+    |> order_by([i], desc: i.inserted_at)
+    |> Repo.all()
+    |> Enum.flat_map(fn insight ->
+      Enum.map(insight.data, fn item ->
+        %{
+          company: item["company"] || insight.source,
+          title: item["title"],
+          url: item["url"],
+          date: item["date"],
+          summary: item["summary"],
+          inserted_at: insight.inserted_at
+        }
+      end)
+    end)
+    |> Enum.group_by(& &1.company)
+    |> Enum.map(fn {company, items} ->
+      sorted = Enum.sort_by(items, & &1.inserted_at, {:desc, DateTime})
+      {company, Enum.take(sorted, limit)}
+    end)
+  end
+end

--- a/dashboard_gen/lib/dashboard_gen_web/components/layout_components.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/components/layout_components.ex
@@ -22,6 +22,9 @@ defmodule DashboardGenWeb.LayoutComponents do
         <.link navigate={~p"/saved"} class="flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-md">
           💾 <%= unless @collapsed, do: "Saved Views" %>
         </.link>
+        <.link navigate={~p"/insights"} class="flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-md">
+          📰 <%= unless @collapsed, do: "Insights" %>
+        </.link>
         <.link navigate={~p"/settings"} class="flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-md">
           ⚙️ <%= unless @collapsed, do: "Settings" %>
         </.link>

--- a/dashboard_gen/lib/dashboard_gen_web/live/competitor_insights_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/competitor_insights_live.ex
@@ -1,0 +1,30 @@
+defmodule DashboardGenWeb.CompetitorInsightsLive do
+  use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :dashboard}
+  use DashboardGenWeb, :html
+
+  alias DashboardGen.Insights
+
+  @impl true
+  def mount(_params, _session, socket) do
+    insights = Insights.list_recent_insights_by_company()
+    companies = Enum.map(insights, &elem(&1, 0))
+
+    {:ok,
+     assign(socket,
+       page_title: "Competitor Insights",
+       collapsed: false,
+       insights_by_company: insights,
+       companies: companies,
+       company_filter: ""
+     )}
+  end
+
+  @impl true
+  def handle_event("toggle_sidebar", _params, socket) do
+    {:noreply, update(socket, :collapsed, &(!&1))}
+  end
+
+  def handle_event("filter_company", %{"company" => company}, socket) do
+    {:noreply, assign(socket, :company_filter, company)}
+  end
+end

--- a/dashboard_gen/lib/dashboard_gen_web/live/competitor_insights_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/competitor_insights_live.html.heex
@@ -1,0 +1,34 @@
+<h1 class="text-xl font-semibold mb-4"><%= @page_title %></h1>
+
+<form phx-change="filter_company" class="mb-4">
+  <select name="company" class="border rounded px-2 py-1 text-sm">
+    <option value="" selected={@company_filter == ""}>All Companies</option>
+    <%= for comp <- @companies do %>
+      <option value={comp} selected={@company_filter == comp}><%= comp %></option>
+    <% end %>
+  </select>
+</form>
+
+<div class="grid gap-6 md:grid-cols-2">
+  <%= for {company, items} <- @insights_by_company do %>
+    <%= if @company_filter in ["", company] do %>
+      <div class="bg-white rounded-md shadow-sm p-4 border">
+        <h2 class="text-sm font-semibold mb-2"><%= company %></h2>
+        <div class="text-xs text-gray-600 mb-3">
+          Most frequent topics: real estate, private equity, fundraising
+        </div>
+        <ul class="space-y-2">
+          <%= for item <- items do %>
+            <li>
+              <a href={item.url} class="text-blue-600 hover:underline" target="_blank"><%= item.title %></a>
+              <div class="text-xs text-gray-500"><%= item.date %></div>
+              <div :if={item.summary} class="text-xs text-gray-700 mt-1">
+                <%= item.summary %>
+              </div>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/dashboard_gen/lib/dashboard_gen_web/router.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/router.ex
@@ -32,6 +32,7 @@ defmodule DashboardGenWeb.Router do
     live("/dashboard", DashboardLive)
     live("/onboarding", OnboardingLive)
     live("/saved", SavedLive)
+    live("/insights", CompetitorInsightsLive)
     live("/settings", SettingsLive)
     live("/uploads", UploadsLive)
   end


### PR DESCRIPTION
## Summary
- add `CompetitorInsightsLive` with page template
- add new Insights context to fetch latest scraped data
- route `/insights` to the new liveview
- extend sidebar navigation with an "Insights" link

## Testing
- `mix compile` *(fails: Could not find an SCM for dependency)*
- `mix test` *(fails: Mix requires the Hex package manager)*

------
https://chatgpt.com/codex/tasks/task_e_687afde32450833191bf32f803ea2317