### PR TITLE
Add topic summary generation for competitor insights

### DIFF
--- a/dashboard_gen/lib/dashboard_gen/insights.ex
+++ b/dashboard_gen/lib/dashboard_gen/insights.ex
@@ -6,6 +6,8 @@ defmodule DashboardGen.Insights do
   import Ecto.Query, warn: false
   alias DashboardGen.Repo
   alias DashboardGen.Scrapers.Insight
+  alias DashboardGen.Insights.TopicSummary
+  alias DashboardGen.CodexClient
 
   @doc """
   Returns insights grouped by company. Each company will include the
@@ -33,5 +35,70 @@ defmodule DashboardGen.Insights do
       sorted = Enum.sort_by(items, &(&1.inserted_at || ~N[1970-01-01 00:00:00]), {:desc, NaiveDateTime})
       {company, Enum.take(sorted, limit)}
     end)
+  end
+
+  @doc """
+  Generate or fetch a cached summary of common topics for the given company.
+  A new summary will be requested from OpenAI if none exists within the
+  last 24 hours.
+  """
+  def generate_topic_summary(company) when is_binary(company) do
+    case get_recent_summary(company) do
+      %TopicSummary{summary: summary} -> {:ok, summary}
+      nil -> do_generate_summary(company)
+    end
+  end
+
+  defp do_generate_summary(company) do
+    with insights when insights != [] <- list_company_insights(company, 90),
+         text <-
+           insights
+           |> Enum.flat_map(fn i -> [i.title, i.content] end)
+           |> Enum.reject(&is_nil/1)
+           |> Enum.join("\n"),
+         prompt <-
+           """
+           You are analyzing a list of recent press releases from #{company}. Summarize the most common topics or themes they focus on.
+           #{text}
+           """
+           |> String.trim(),
+         {:ok, summary} <- CodexClient.ask(prompt),
+         {:ok, _rec} <-
+           %TopicSummary{}
+           |> TopicSummary.changeset(%{company: company, summary: summary})
+           |> Repo.insert() do
+      {:ok, summary}
+    else
+      [] -> {:error, :no_insights}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp get_recent_summary(company) do
+    from(s in TopicSummary,
+      where: s.company == ^company and s.inserted_at > ago(1, "day"),
+      order_by: [desc: s.inserted_at],
+      limit: 1
+    )
+    |> Repo.one()
+  end
+
+  defp list_company_insights(company, days) do
+    cutoff = DateTime.utc_now() |> DateTime.add(-days * 86_400, :second)
+
+    Insight
+    |> where([i], i.inserted_at >= ^cutoff)
+    |> Repo.all()
+    |> Enum.flat_map(fn insight ->
+      Enum.map(insight.data, fn item ->
+        %{
+          company: item["company"] || insight.source,
+          title: item["title"],
+          content: item["content"] || item["summary"],
+          inserted_at: insight.inserted_at
+        }
+      end)
+    end)
+    |> Enum.filter(&(&1.company == company))
   end
 end

--- a/dashboard_gen/lib/dashboard_gen/insights/topic_summary.ex
+++ b/dashboard_gen/lib/dashboard_gen/insights/topic_summary.ex
@@ -1,0 +1,18 @@
+defmodule DashboardGen.Insights.TopicSummary do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "insight_summaries" do
+    field :company, :string
+    field :summary, :string
+
+    timestamps(updated_at: false)
+  end
+
+  @doc false
+  def changeset(summary, attrs) do
+    summary
+    |> cast(attrs, [:company, :summary])
+    |> validate_required([:company, :summary])
+  end
+end

--- a/dashboard_gen/lib/dashboard_gen_web/live/competitor_insights_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/competitor_insights_live.html.heex
@@ -14,8 +14,15 @@
     <%= if @company_filter in ["", company] do %>
       <div class="bg-white rounded-md shadow-sm p-4 border">
         <h2 class="text-sm font-semibold mb-2"><%= company %></h2>
-        <div class="text-xs text-gray-600 mb-3">
-          Most frequent topics: real estate, private equity, fundraising
+        <div class="text-xs text-gray-600 mb-3 italic">
+          <%= if summary = @summaries[company] do %>
+            <%= summary %>
+          <% else %>
+            <span :if={company in @loading_summaries} class="flex items-center gap-1">
+              <span class="h-3 w-3 border-2 border-gray-400 border-t-transparent rounded-full animate-spin"></span>
+              Generating summary...
+            </span>
+          <% end %>
         </div>
         <ul class="space-y-2">
           <%= for item <- items do %>

--- a/dashboard_gen/priv/repo/migrations/20250719010000_create_insight_summaries.exs
+++ b/dashboard_gen/priv/repo/migrations/20250719010000_create_insight_summaries.exs
@@ -1,0 +1,14 @@
+defmodule DashboardGen.Repo.Migrations.CreateInsightSummaries do
+  use Ecto.Migration
+
+  def change do
+    create table(:insight_summaries) do
+      add :company, :string
+      add :summary, :text
+
+      timestamps(updated_at: false)
+    end
+
+    create index(:insight_summaries, [:company])
+  end
+end


### PR DESCRIPTION
## Summary
- create `insight_summaries` table and schema
- add `Insights.generate_topic_summary/1` to query OpenAI and cache results
- show generated summary in competitor insights cards with a loading spinner

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687b04fa090c83318bb72961c64371b7