### PR TITLE
Import CoreComponents in live views

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/components/layout_components.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/components/layout_components.ex
@@ -1,5 +1,6 @@
 defmodule DashboardGenWeb.LayoutComponents do
   use DashboardGenWeb, :html
+  import DashboardGenWeb.CoreComponents
 
   @doc """
   Sidebar navigation

--- a/dashboard_gen/lib/dashboard_gen_web/live/login_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/login_live.ex
@@ -1,6 +1,7 @@
 defmodule DashboardGenWeb.LoginLive do
   use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :dashboard}
   use DashboardGenWeb, :html
+  import DashboardGenWeb.CoreComponents
   alias DashboardGen.Accounts
 
   def mount(_params, _session, socket) do

--- a/dashboard_gen/lib/dashboard_gen_web/live/onboarding_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/onboarding_live.ex
@@ -1,5 +1,7 @@
 defmodule DashboardGenWeb.OnboardingLive do
   use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :dashboard}
+  use DashboardGenWeb, :html
+  import DashboardGenWeb.CoreComponents
   alias DashboardGen.Accounts
 
   def mount(_params, session, socket) do

--- a/dashboard_gen/lib/dashboard_gen_web/live/register_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/register_live.ex
@@ -1,6 +1,7 @@
 defmodule DashboardGenWeb.RegisterLive do
   use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :dashboard}
   use DashboardGenWeb, :html
+  import DashboardGenWeb.CoreComponents
 
   alias DashboardGen.Accounts
   alias DashboardGen.Accounts.User

--- a/dashboard_gen/lib/dashboard_gen_web/live/uploads_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/uploads_live.ex
@@ -1,6 +1,7 @@
 defmodule DashboardGenWeb.UploadsLive do
   use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :dashboard}
   use DashboardGenWeb, :html
+  import DashboardGenWeb.CoreComponents
 
   alias DashboardGen.Uploads
   require Logger


### PR DESCRIPTION
## Summary
- import `DashboardGenWeb.CoreComponents` in various LiveViews and layout components

## Testing
- `mix compile` *(fails: Could not fetch Hex and dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687bad7ef350833180d21dfa9f985d77