### PR TITLE
Fix width of dashboard query input

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
@@ -38,8 +38,8 @@
     <% end %>
   </div>
 
-  <form phx-submit="generate" class="bg-white border rounded-md flex items-center px-4 py-2 shadow-sm mt-6">
-    <.text_input type="text" name="prompt" value={@prompt} placeholder="Describe your query..." class="flex-1 bg-transparent outline-none text-sm" />
+  <form phx-submit="generate" class="bg-white border rounded-md flex items-center px-4 py-2 shadow-sm mt-6 w-full">
+    <.text_input type="text" name="prompt" value={@prompt} placeholder="Describe your query..." class="flex-1 bg-transparent outline-none text-sm w-full" />
     <.button type="submit" variant="secondary" class="p-2 text-gray-600 hover:text-gray-800">➤</.button>
   </form>
 </div>


### PR DESCRIPTION
## Summary
- expand prompt input to fill the full width of the dashboard footer form

## Testing
- `mix test` *(fails: Hex could not be installed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687bb1639304833187c1fd3cf3150bdb