### PR TITLE
Remove `All` option in competitor filter

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/competitor_insights_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/competitor_insights_live.ex
@@ -33,7 +33,7 @@ defmodule DashboardGenWeb.CompetitorInsightsLive do
        companies: companies,
        summaries: summaries,
        loading_summaries: loading,
-       company_filter: ""
+       company_filter: List.first(companies) || ""
      )}
   end
 

--- a/dashboard_gen/lib/dashboard_gen_web/live/competitor_insights_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/competitor_insights_live.html.heex
@@ -2,7 +2,6 @@
 
 <form phx-change="filter_company" class="mb-4">
   <select name="company" class="border rounded px-2 py-1 text-sm">
-    <option value="" selected={@company_filter == ""}>All Companies</option>
     <%= for comp <- @companies do %>
       <option value={comp} selected={@company_filter == comp}><%= comp %></option>
     <% end %>
@@ -11,7 +10,7 @@
 
 <div class="grid gap-6 md:grid-cols-2">
   <%= for {company, items} <- @insights_by_company do %>
-    <%= if @company_filter in ["", company] do %>
+    <%= if @company_filter == company do %>
       <div class="bg-white rounded-md shadow-sm p-4 border">
         <h2 class="text-sm font-semibold mb-2"><%= company %></h2>
         <div class="text-xs text-gray-600 mb-3 italic">


### PR DESCRIPTION
## Summary
- default competitor filter to the first company
- remove ability to show insights for all companies at once

## Testing
- `mix format lib/dashboard_gen_web/live/competitor_insights_live.ex lib/dashboard_gen_web/live/competitor_insights_live.html.heex`
- `mix test` *(fails: Mix requires the Hex package manager)*

------
https://chatgpt.com/codex/tasks/task_e_687bdd41dcf08331b074528708e5164e