### PR TITLE
Add social media scraper

### DIFF
--- a/dashboard_gen/priv/python/scrapers/social_media.py
+++ b/dashboard_gen/priv/python/scrapers/social_media.py
@@ -1,21 +1,59 @@
 import argparse
 import json
 import sys
-import time
 
 
-def scrape(company: str):
-    # Placeholder for scraping social media via APIs
-    time.sleep(1)
+def scrape_blackstone():
+    """Return mocked social media posts for Blackstone."""
     return [
         {
-            "company": company.title(),
-            "title": "Social Post",
-            "content": "Mock social media mention.",
+            "company": "Blackstone",
+            "content": "Blackstone announces new infrastructure fund launch.",
+            "url": "https://social.example.com/blackstone/post/1",
+            "date": "2024-05-05",
+            "source": "social_media",
+        },
+        {
+            "company": "Blackstone",
+            "content": "CEO discusses market outlook on major news outlet.",
+            "url": "https://social.example.com/blackstone/post/2",
+            "date": "2024-05-04",
+            "source": "social_media",
+        },
+        {
+            "company": "Blackstone",
+            "content": "Celebrating a successful portfolio company IPO.",
+            "url": "https://social.example.com/blackstone/post/3",
+            "date": "2024-05-03",
+            "source": "social_media",
+        },
+    ]
+
+
+def scrape_jpmorgan():
+    """Return mocked social media posts for JP Morgan."""
+    return [
+        {
+            "company": "JP Morgan",
+            "content": "JP Morgan unveils new digital banking features.",
+            "url": "https://social.example.com/jpmorgan/post/1",
+            "date": "2024-05-06",
+            "source": "social_media",
+        },
+        {
+            "company": "JP Morgan",
+            "content": "Analysts applaud JP Morgan quarterly earnings beat.",
+            "url": "https://social.example.com/jpmorgan/post/2",
+            "date": "2024-05-04",
+            "source": "social_media",
+        },
+        {
+            "company": "JP Morgan",
+            "content": "Community outreach event highlights financial literacy.",
+            "url": "https://social.example.com/jpmorgan/post/3",
             "date": "2024-05-02",
             "source": "social_media",
-            "url": f"https://social.example.com/{company}/post/1",
-        }
+        },
     ]
 
 
@@ -23,7 +61,14 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--company", default="blackstone")
     args = parser.parse_args()
-    data = scrape(args.company)
+
+    if args.company == "blackstone":
+        data = scrape_blackstone()
+    elif args.company == "jpmorgan":
+        data = scrape_jpmorgan()
+    else:
+        raise ValueError(f"Unsupported company: {args.company}")
+
     json.dump(data, sys.stdout)
 
 


### PR DESCRIPTION
## Summary
- add `social_media.py` with routes for blackstone and jpmorgan posts
- keep scraper default `--company` argument
- include `social_media.py` in Elixir scraper list

## Testing
- `mix test` *(fails: could not install Hex)*

------
https://chatgpt.com/codex/tasks/task_e_687bde9f57408331ac8251455bafcd93