### PR TITLE
Add social media insights view

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/competitor_insights_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/competitor_insights_live.ex
@@ -1,6 +1,7 @@
 defmodule DashboardGenWeb.CompetitorInsightsLive do
   use Phoenix.LiveView, layout: {DashboardGenWeb.Layouts, :dashboard}
   use DashboardGenWeb, :html
+  import DashboardGenWeb.CoreComponents
 
   alias DashboardGen.Insights
 
@@ -59,6 +60,25 @@ defmodule DashboardGenWeb.CompetitorInsightsLive do
 
       _ ->
         {:noreply, update(socket, :loading_summaries, &MapSet.delete(&1, company))}
+    end
+  end
+
+  defp snippet(text, len \\ 140)
+  defp snippet(nil, _len), do: ""
+
+  defp snippet(text, len) do
+    text
+    |> String.replace("\n", " ")
+    |> String.slice(0, len)
+    |> String.trim()
+  end
+
+  defp platform_icon(url) do
+    cond do
+      is_nil(url) -> "chat-bubble-left-right"
+      String.contains?(url, "twitter") -> "twitter"
+      String.contains?(url, "linkedin") -> "linkedin"
+      true -> "chat-bubble-left-right"
     end
   end
 end

--- a/dashboard_gen/lib/dashboard_gen_web/live/competitor_insights_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/competitor_insights_live.html.heex
@@ -9,7 +9,7 @@
 </form>
 
 <div class="grid gap-6 md:grid-cols-2">
-  <%= for {company, items} <- @insights_by_company do %>
+  <%= for {company, data} <- @insights_by_company do %>
     <%= if @company_filter == company do %>
       <div class="bg-white rounded-md shadow-sm p-4 border">
         <h2 class="text-sm font-semibold mb-2"><%= company %></h2>
@@ -23,17 +23,41 @@
             </span>
           <% end %>
         </div>
-        <ul class="space-y-2">
-          <%= for item <- items do %>
-            <li>
-              <a href={item.url} class="text-blue-600 hover:underline" target="_blank"><%= item.title %></a>
-              <div class="text-xs text-gray-500"><%= item.date %></div>
-              <div :if={item.summary} class="text-xs text-gray-700 mt-1">
-                <%= item.summary %>
-              </div>
-            </li>
-          <% end %>
-        </ul>
+
+        <div class="grid md:grid-cols-2 gap-4">
+          <div>
+            <h3 class="text-xs font-medium mb-2">Press Releases</h3>
+            <ul class="space-y-2">
+              <%= for item <- data.press_releases do %>
+                <li>
+                  <a href={item.url} class="text-blue-600 hover:underline" target="_blank"><%= item.title %></a>
+                  <div class="text-xs text-gray-500"><%= item.date %></div>
+                  <div :if={item.summary} class="text-xs text-gray-700 mt-1">
+                    <%= item.summary %>
+                  </div>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+
+          <div>
+            <h3 class="text-xs font-medium mb-2">Social Media</h3>
+            <ul class="space-y-2">
+              <%= for post <- data.social_media do %>
+                <li class="flex items-start gap-2">
+                  <.icon name={platform_icon(post.url)} class="h-4 w-4 mt-0.5" />
+                  <div>
+                    <div class="text-sm"><%= snippet(post.content) %></div>
+                    <div class="text-xs text-gray-500">
+                      <%= post.date %>
+                      <a :if={post.url} href={post.url} target="_blank" class="ml-1 text-blue-600 hover:underline">Link</a>
+                    </div>
+                  </div>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        </div>
       </div>
     <% end %>
   <% end %>


### PR DESCRIPTION
## Summary
- group recent insights by source in `Insights.list_recent_insights_by_company/1`
- import design system helpers in `CompetitorInsightsLive`
- render social media posts next to press releases

## Testing
- `mix test` *(fails: Mix requires Hex package manager)*

------
https://chatgpt.com/codex/tasks/task_e_687be05c43448331ae7fe3911c1b807e