### PR TITLE
Fix compile warnings

### DIFF
--- a/dashboard_gen/lib/dashboard_gen/scrapers.ex
+++ b/dashboard_gen/lib/dashboard_gen/scrapers.ex
@@ -67,7 +67,7 @@ defmodule DashboardGen.Scrapers do
 
     case File.exists?(path) do
       true ->
-        {_, status} = System.cmd("python3", [path, "--company", company], stderr_to_stdout: true)
+        {_, _status} = System.cmd("python3", [path, "--company", company], stderr_to_stdout: true)
 
         output_path = Path.join(File.cwd!(), "scrape_output.json")
 

--- a/dashboard_gen/lib/dashboard_gen_web/components/layouts/root.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/components/layouts/root.html.heex
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <%= csrf_meta_tag() %>
-    <%= live_title_tag assigns[:page_title] || "DashboardGen" %>
+    <.live_title><%= assigns[:page_title] || "DashboardGen" %></.live_title>
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
     <script src="https://cdn.jsdelivr.net/npm/vega@5" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/vega-lite@5" defer></script>

--- a/dashboard_gen/lib/dashboard_gen_web/core_components.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/core_components.ex
@@ -26,12 +26,13 @@ defmodule DashboardGenWeb.CoreComponents do
   """
   attr(:variant, :string, default: "primary")
   attr(:class, :string, default: nil)
+  attr(:disabled, :boolean, default: false)
   attr(:rest, :global, default: %{})
   slot(:inner_block, required: true)
 
   def button(assigns) do
     ~H"""
-    <button class={[button_classes(@variant), @class]} {@rest}>
+    <button class={[button_classes(@variant), @class]} disabled={@disabled} {@rest}>
       <%= render_slot(@inner_block) %>
     </button>
     """
@@ -46,11 +47,25 @@ defmodule DashboardGenWeb.CoreComponents do
   @doc """
   Text input component with AB styles
   """
+  attr(:type, :string, default: "text")
+  attr(:name, :string, default: nil)
+  attr(:value, :any, default: nil)
+  attr(:placeholder, :string, default: nil)
+  attr(:disabled, :boolean, default: false)
+  attr(:class, :string, default: nil)
   attr(:rest, :global, default: %{})
 
   def text_input(assigns) do
     ~H"""
-    <input class="border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:border-brandBlue focus:ring-1 focus:ring-brandBlue" {@rest} />
+    <input
+      type={@type}
+      name={@name}
+      value={@value}
+      placeholder={@placeholder}
+      disabled={@disabled}
+      class={["border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:border-brandBlue focus:ring-1 focus:ring-brandBlue", @class]}
+      {@rest}
+    />
     """
   end
 end

--- a/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/dashboard_live.html.heex
@@ -4,8 +4,8 @@
       <span><%= @page_title %></span>
       <.button phx-click="run_scrapers" class="ml-2 px-2 py-1 text-xs">Run Scrapers</.button>
     </h1>
-    <%= if live_flash(@flash, :error) do %>
-      <div class="rounded-md border p-4 bg-white shadow-sm text-red-600"><%= live_flash(@flash, :error) %></div>
+    <%= if Phoenix.Flash.get(@flash, :error) do %>
+      <div class="rounded-md border p-4 bg-white shadow-sm text-red-600"><%= Phoenix.Flash.get(@flash, :error) %></div>
     <% end %>
 
     <%= if @loading do %>

--- a/dashboard_gen/lib/dashboard_gen_web/live/saved_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/saved_live.ex
@@ -7,6 +7,7 @@ defmodule DashboardGenWeb.SavedLive do
     {:ok, assign(socket, page_title: "Saved Views", collapsed: false)}
   end
 
+  @impl true
   def handle_event("toggle_sidebar", _params, socket) do
     {:noreply, update(socket, :collapsed, &(!&1))}
   end

--- a/dashboard_gen/lib/dashboard_gen_web/live/settings_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/settings_live.ex
@@ -7,6 +7,7 @@ defmodule DashboardGenWeb.SettingsLive do
     {:ok, assign(socket, page_title: "Settings", collapsed: false)}
   end
 
+  @impl true
   def handle_event("toggle_sidebar", _params, socket) do
     {:noreply, update(socket, :collapsed, &(!&1))}
   end

--- a/dashboard_gen/lib/dashboard_gen_web/live/uploads_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/uploads_live.ex
@@ -37,7 +37,6 @@ defmodule DashboardGenWeb.UploadsLive do
     {:noreply, update(socket, :collapsed, &(!&1))}
   end
 
-  @impl true
   def handle_progress(:csv, entry, socket) when entry.done? do
     Logger.info("Finished uploading #{entry.client_name}")
     label = socket.assigns[:label] || "Untitled Upload"

--- a/dashboard_gen/lib/dashboard_gen_web/live/uploads_live.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/uploads_live.html.heex
@@ -1,6 +1,6 @@
 <h1 class="text-xl font-semibold mb-4"><%= @page_title %></h1>
 <div class="bg-white rounded-md shadow-sm p-4 mb-6 border">
-  <.form id="upload-form" phx-change="validate" phx-submit="noop" multipart={true} class="space-y-2">
+  <form id="upload-form" phx-change="validate" phx-submit="noop" multipart={true} class="space-y-2">
     <.text_input type="text" name="label" value={@label} placeholder="Optional label" class="text-sm" />
 
     <div phx-drop-target={@uploads.csv.ref}>
@@ -15,7 +15,7 @@
       <progress value={entry.progress} max="100" class="w-full mt-2"></progress>
     <% end %>
     <.button type="submit" class="rounded-full text-sm" disabled={@uploading?}>Upload</.button>
-  </.form>
+  </form>
 </div>
 
 <div class="mt-6 space-y-4">

--- a/dashboard_gen/lib/dashboard_gen_web/live_helpers.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live_helpers.ex
@@ -8,7 +8,7 @@ defmodule DashboardGenWeb.LiveHelpers do
   """
   def maybe_put_session(socket, key, value) do
     if function_exported?(Phoenix.LiveView, :put_session, 3) do
-      Phoenix.LiveView.put_session(socket, key, value)
+      apply(Phoenix.LiveView, :put_session, [socket, key, value])
     else
       socket
     end

--- a/dashboard_gen/lib/dashboard_gen_web/templates/layout/root.html.heex
+++ b/dashboard_gen/lib/dashboard_gen_web/templates/layout/root.html.heex
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <%= csrf_meta_tag() %>
-    <%= live_title_tag assigns[:page_title] || "DashboardGen" %>
+    <.live_title><%= assigns[:page_title] || "DashboardGen" %></.live_title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
   </head>


### PR DESCRIPTION
## Summary
- allow `button` and `text_input` components to accept more attributes
- remove `@impl true` from uploads callback and add it to other events
- update live helpers to avoid undefined `put_session`
- switch deprecated `live_flash` and `live_title_tag` usages
- fix unused variable warning and replace `form` component

## Testing
- `mix format` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687c066519c48331930d4dd69f8b7ce3