### PR TITLE
Update scrapers for BlackRock and JPMAM

### DIFF
--- a/dashboard_gen/lib/dashboard_gen/scrapers.ex
+++ b/dashboard_gen/lib/dashboard_gen/scrapers.ex
@@ -7,7 +7,7 @@ defmodule DashboardGen.Scrapers do
   alias DashboardGen.Scrapers.Insight
 
   @scripts ["competitor_sites.py", "social_media.py"]
-  @press_release_companies ~w(blackstone jpmorgan)
+  @press_release_companies ~w(blackrock jp-morgan-am)
 
   priv_dir = :code.priv_dir(:dashboard_gen) |> to_string()
   @scripts_path Path.join([priv_dir, "python", "scrapers"])
@@ -40,7 +40,7 @@ defmodule DashboardGen.Scrapers do
       true ->
         case script do
           "social_media.py" ->
-            ["blackstone", "jpmorgan"]
+            ["blackrock", "jp-morgan-am"]
             |> Enum.map(&run_script(path, Path.rootname(script), ["--company", &1]))
             |> Enum.find(fn result -> match?({:error, _}, result) end)
             |> case do

--- a/dashboard_gen/priv/python/scrapers/competitor_sites.py
+++ b/dashboard_gen/priv/python/scrapers/competitor_sites.py
@@ -22,7 +22,7 @@ def scrape(company: str):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--company", default="blackstone")
+    parser.add_argument("--company", default="blackrock")
     args = parser.parse_args()
     data = scrape(args.company)
     json.dump(data, sys.stdout)

--- a/dashboard_gen/priv/python/scrapers/press_releases.py
+++ b/dashboard_gen/priv/python/scrapers/press_releases.py
@@ -4,64 +4,40 @@ import sys
 import requests
 import time
 from bs4 import BeautifulSoup
-from playwright.sync_api import sync_playwright
+from typing import List, Dict
 
 
-def scrape_blackstone():
-    url = "https://www.blackstone.com/news/press/"
-    headers = {"User-Agent": "Mozilla/5.0"}
 
-    res = requests.get(url, headers=headers)
-    soup = BeautifulSoup(res.text, "html.parser")
-    articles = soup.select("article.bx-article-column")
-
-    results = []
-
-    for article in articles:
-        title_el = article.select_one("h4.bx-article-title a")
-        date_el = article.select_one("p.bx-article-post_date")
-
-        if title_el:
-            results.append({
-                "company": "Blackstone",
-                "title": title_el.get_text(strip=True),
-                "url": title_el["href"],
-                "date": date_el.get_text(strip=True) if date_el else None,
-                "content": "",
-                "source": "press_release"
-            })
-
-    return results
-
-def scrape_jpmorgan():
-    url = (
-        "https://www.jpmorgan.com/services/json/v1/dynamic-grid.service/"
-        "parent=jpmorgan/global/US/en/about-us/corporate-news&"
-        "comp=root/content-parsys/multi_tab_copy_copy/tab-par-2/dynamic_grid_copy&"
-        "page=p1.json"
-    )
-
-    headers = {
-        "User-Agent": "Mozilla/5.0"
-    }
-
-    res = requests.get(url, headers=headers)
+def _parse_rss(feed_url: str, company: str) -> List[Dict]:
+    res = requests.get(feed_url, headers={"User-Agent": "Mozilla/5.0"})
     res.raise_for_status()
-    data = res.json()
+    soup = BeautifulSoup(res.text, "xml")
 
-    results = []
+    items = []
+    for item in soup.select("item"):
+        items.append(
+            {
+                "company": company,
+                "title": item.findtext("title", "").strip(),
+                "url": item.findtext("link", "").strip(),
+                "date": item.findtext("pubDate", "").strip(),
+                "content": item.findtext("description", "").strip(),
+                "source": "press_release",
+            }
+        )
 
-    for item in data.get("items", []):
-        results.append({
-            "company": "JP Morgan",
-            "title": item.get("title", "").strip(),
-            "url": "https://www.jpmorgan.com" + item.get("link", ""),
-            "date": item.get("date", ""),
-            "content": item.get("description", ""),
-            "source": "press_release"
-        })
+    return items
 
-    return results
+
+def scrape_blackrock() -> List[Dict]:
+    # BlackRock provides an RSS feed for press releases
+    feed = "https://www.blackrock.com/corporate/newsroom/press-releases?rss=true"
+    return _parse_rss(feed, "BlackRock")
+
+def scrape_jp_morgan_am() -> List[Dict]:
+    # JP Morgan Asset Management RSS feed for press releases
+    feed = "https://am.jpmorgan.com/us/en/asset-management/adv/_jcr_content/pressReleaseFeed.xml"
+    return _parse_rss(feed, "J.P. Morgan Asset Management")
 
 
 def main():
@@ -70,10 +46,10 @@ def main():
     args = parser.parse_args()
 
     try:
-        if args.company == "blackstone":
-            data = scrape_blackstone()
-        elif args.company == "jpmorgan":
-            data = scrape_jpmorgan()
+        if args.company == "blackrock":
+            data = scrape_blackrock()
+        elif args.company == "jp-morgan-am":
+            data = scrape_jp_morgan_am()
         else:
             raise ValueError(f"Unsupported company: {args.company}")
 
@@ -83,10 +59,6 @@ def main():
     except Exception as e:
         with open("scrape_output.json", "w") as f:
             json.dump({"error": str(e)}, f)
-
-
-if __name__ == "__main__":
-    main()
 
 
 if __name__ == "__main__":

--- a/dashboard_gen/priv/python/scrapers/social_media.py
+++ b/dashboard_gen/priv/python/scrapers/social_media.py
@@ -13,19 +13,24 @@ from bs4 import BeautifulSoup
 
 HEADERS = {"User-Agent": "Mozilla/5.0"}
 
+COMPANY_NAMES = {
+    "blackrock": "BlackRock",
+    "jp-morgan-am": "J.P. Morgan Asset Management",
+}
+
 # Static social handles used for scraping. The Elixir application passes
-# the company key (e.g. "blackstone") which we use to look up the
+# the company key (e.g. "blackrock") which we use to look up the
 # appropriate handle per platform. Any platform without a handle will be
 # skipped when scraping.
 COMPANY_HANDLES = {
-    "blackstone": {
-        "x": "blackstone",
-        "linkedin": "blackstone-group",
-        "youtube": "UC1q4bW9z9u6H_JvCQWrOXZw",  # channel_id
+    "blackrock": {
+        "x": "blackrock",
+        "linkedin": "blackrock",
+        "youtube": "UC1hV9Fb-Lw5ome1D9fQhs6A",
     },
-    "jpmorgan": {
-        "x": "jpmorgan",
-        "linkedin": "jpmorganchase",
+    "jp-morgan-am": {
+        "x": "JPMAM",
+        "linkedin": "jpmam",
         "youtube": "UCq3gDLkoL0YmCwqHi9nZxtA",
     },
 }
@@ -67,7 +72,7 @@ def scrape_x(company: str) -> List[Dict]:
         date = date_el.get("title") or date_el.text
         posts.append(
             {
-                "company": company.title(),
+                "company": COMPANY_NAMES.get(company, company.title()),
                 "platform": "X",
                 "content": content_el.get_text(" ", strip=True),
                 "date": date.split(" ")[0],
@@ -99,7 +104,7 @@ def scrape_linkedin(company: str) -> List[Dict]:
         date = date_el.get_text(strip=True) if date_el else ""
         posts.append(
             {
-                "company": company.title(),
+                "company": COMPANY_NAMES.get(company, company.title()),
                 "platform": "LinkedIn",
                 "content": text,
                 "date": date,
@@ -140,7 +145,7 @@ def scrape_youtube(company: str) -> List[Dict]:
 
         posts.append(
             {
-                "company": company.title(),
+                "company": COMPANY_NAMES.get(company, company.title()),
                 "platform": "YouTube",
                 "content": title_el.text,
                 "date": date.date().isoformat(),


### PR DESCRIPTION
## Summary
- rename Blackstone/JPMorgan logic to new slugs
- scrape BlackRock and J.P. Morgan Asset Management press releases via RSS
- update social media handles for BlackRock and JPMAM
- adjust Elixir scraper runner for the new company identifiers
- default competitor stub to BlackRock

## Testing
- `mix test` *(fails: Hex installation requires internet)*

------
https://chatgpt.com/codex/tasks/task_e_687c2a9b21a4833185d274724d117693