### PR TITLE
Fix login session persistence with redirect

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/login_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/login_live.ex
@@ -14,7 +14,7 @@ defmodule DashboardGenWeb.LoginLive do
         {:noreply,
          socket
          |> DashboardGenWeb.LiveHelpers.maybe_put_session(:user_id, user.id)
-         |> Phoenix.LiveView.push_navigate(to: "/dashboard")}
+         |> Phoenix.LiveView.redirect(to: "/dashboard")}
 
       :error ->
         {:noreply, assign(socket, error: "Invalid email or password")}

--- a/dashboard_gen/lib/dashboard_gen_web/live/register_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/register_live.ex
@@ -17,7 +17,7 @@ defmodule DashboardGenWeb.RegisterLive do
         {:noreply,
          socket
          |> DashboardGenWeb.LiveHelpers.maybe_put_session(:user_id, user.id)
-         |> Phoenix.LiveView.push_navigate(to: "/onboarding")}
+         |> Phoenix.LiveView.redirect(to: "/onboarding")}
 
       {:error, changeset} ->
         {:noreply, assign(socket, changeset: changeset)}


### PR DESCRIPTION
## Summary
- persist session during login and register by redirecting instead of pushing navigate

## Testing
- `mix test` *(fails: Mix requires the Hex package manager)*

------
https://chatgpt.com/codex/tasks/task_e_687d977dcb5883318fe14d0f9bff1d50