### PR TITLE
Fix login session handling

### DIFF
--- a/dashboard_gen/lib/dashboard_gen_web/live/login_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/login_live.ex
@@ -15,14 +15,16 @@ defmodule DashboardGenWeb.LoginLive do
           {:ok, session} ->
             {:noreply,
              socket
+             |> DashboardGenWeb.LiveHelpers.maybe_put_session(:session_token, session.token)
              |> DashboardGenWeb.LiveHelpers.maybe_put_session(:user_id, user.id)
              |> Phoenix.LiveView.redirect(to: "/dashboard")}
+
           {:error, _} ->
             {:noreply, assign(socket, error: "Unable to create session. Please try again.")}
         end
+
       :error ->
         {:noreply, assign(socket, error: "Invalid email or password")}
     end
   end
-
 end

--- a/dashboard_gen/lib/dashboard_gen_web/live/register_live.ex
+++ b/dashboard_gen/lib/dashboard_gen_web/live/register_live.ex
@@ -18,18 +18,25 @@ defmodule DashboardGenWeb.RegisterLive do
           {:ok, session} ->
             {:noreply,
              socket
+             |> DashboardGenWeb.LiveHelpers.maybe_put_session(:session_token, session.token)
              |> DashboardGenWeb.LiveHelpers.maybe_put_session(:user_id, user.id)
              |> Phoenix.LiveView.redirect(to: "/onboarding")}
+
           {:error, _} ->
-            changeset = User.registration_changeset(%User{}, user_params)
-            |> Ecto.Changeset.add_error(:password, "Unable to create session. Please try again.")
+            changeset =
+              User.registration_changeset(%User{}, user_params)
+              |> Ecto.Changeset.add_error(
+                :password,
+                "Unable to create session. Please try again."
+              )
+
             {:noreply, assign(socket, changeset: changeset)}
         end
+
       {:error, changeset} ->
         {:noreply, assign(socket, changeset: changeset)}
     end
   end
-
 
   defp error_tag(form, field) do
     Enum.map(Keyword.get_values(form.errors, field), fn {message, _opts} ->


### PR DESCRIPTION
## Summary
- store `session_token` alongside `user_id` when creating sessions
- update registration to store session token so login works

## Testing
- `mix test` *(fails: Mix requires the Hex package manager)*

------
https://chatgpt.com/codex/tasks/task_e_687da1a4bf6c8331b286c586e666b9b7